### PR TITLE
docs: Three-Power Separation spec, Mantis component, Receipt v2.1, API catalog, architecture v2.7

### DIFF
--- a/docs/API_CATALOG_v2.7.md
+++ b/docs/API_CATALOG_v2.7.md
@@ -1,0 +1,810 @@
+# RIO Gateway — API Endpoint Catalog
+
+**Version:** 2.7.0
+**Date:** 2026-03-31
+**Author:** Romney (Manus Agent)
+**Base URL (Production):** `https://rio-gateway.onrender.com`
+
+---
+
+## Table of Contents
+
+1. [Authentication](#1-authentication)
+2. [Core Pipeline Endpoints](#2-core-pipeline-endpoints)
+3. [Public API v1 Endpoints](#3-public-api-v1-endpoints)
+4. [Identity & Signer Management](#4-identity--signer-management)
+5. [Key Backup & Recovery](#5-key-backup--recovery)
+6. [Device Sync](#6-device-sync)
+7. [Proxy Onboarding (v2.7.0)](#7-proxy-onboarding-v270)
+8. [Observability](#8-observability)
+9. [Authentication Methods](#9-authentication-methods)
+10. [Error Responses](#10-error-responses)
+
+---
+
+## 1. Authentication
+
+### POST /login
+
+Authenticate and receive a JWT token.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | No |
+| Rate Limited | No |
+| Replay Prevention | Yes |
+
+**Request Body:**
+```json
+{
+  "user_id": "brian.k.rasmussen",
+  "passphrase": "rio-governed-2026",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (200):**
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIs...",
+  "user": {
+    "sub": "brian.k.rasmussen",
+    "role": "owner"
+  },
+  "expires_in": "24h"
+}
+```
+
+### GET /whoami
+
+Return the authenticated user's identity.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Rate Limited | No |
+
+**Response (200):**
+```json
+{
+  "authenticated": true,
+  "user": {
+    "sub": "brian.k.rasmussen",
+    "role": "owner",
+    "iat": 1743451200,
+    "exp": 1743537600
+  }
+}
+```
+
+---
+
+## 2. Core Pipeline Endpoints
+
+These endpoints implement the 7-stage governance pipeline. They are mounted at the root path and accept JWT authentication.
+
+### POST /intent
+
+Submit a new intent for governance evaluation.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT (optional for submission) |
+| Replay Prevention | Yes |
+| Ledger Entry | `submit` |
+
+**Request Body:**
+```json
+{
+  "action": "send_email",
+  "agent_id": "manus",
+  "parameters": {
+    "to": "recipient@example.com",
+    "subject": "Test",
+    "body": "Hello from RIO"
+  },
+  "confidence": 95,
+  "target_environment": "production",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (201):**
+```json
+{
+  "intent_id": "uuid-v4",
+  "status": "submitted",
+  "hash": "sha256-hex",
+  "message": "Intent submitted successfully."
+}
+```
+
+### POST /govern
+
+Evaluate an intent against governance policy.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Replay Prevention | Yes |
+| Ledger Entry | `govern` |
+
+**Request Body:**
+```json
+{
+  "intent_id": "uuid-v4",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (200):**
+```json
+{
+  "intent_id": "uuid-v4",
+  "status": "auto_approved | requires_approval | blocked",
+  "governance": {
+    "checks": [
+      { "check": "constitution_loaded", "passed": true },
+      { "check": "policy_loaded", "passed": true },
+      { "check": "agent_recognized", "passed": true, "agent": "manus" },
+      { "check": "environment_valid", "passed": true },
+      { "check": "action_classification", "restricted": false },
+      { "check": "confidence_threshold", "passed": true, "confidence": 95 },
+      { "check": "external_effect", "detected": true }
+    ],
+    "risk_level": "medium",
+    "requires_approval": true
+  }
+}
+```
+
+### POST /authorize
+
+Authorize a governed intent (approve or deny).
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Ed25519 Signature | Required when `ED25519_MODE=required` |
+| Replay Prevention | Yes |
+| Ledger Entry | `authorize` |
+| Token Burn | Issues single-use execution token |
+
+**Request Body:**
+```json
+{
+  "intent_id": "uuid-v4",
+  "decision": "approved",
+  "signer_id": "brian-sovereign",
+  "signature": "ed25519-hex-signature",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (200):**
+```json
+{
+  "intent_id": "uuid-v4",
+  "status": "authorized",
+  "execution_token": "uuid-v4",
+  "token_expires_at": "2026-03-31T20:05:00.000Z",
+  "ed25519_signed": true,
+  "signer_id": "brian-sovereign"
+}
+```
+
+### POST /execute
+
+Execute an authorized intent using a single-use token.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Execution Token | Required (single-use, burns on use) |
+| Replay Prevention | Yes |
+| Ledger Entry | `execute` |
+
+**Request Body:**
+```json
+{
+  "intent_id": "uuid-v4",
+  "execution_token": "uuid-v4",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (200):**
+```json
+{
+  "intent_id": "uuid-v4",
+  "status": "executed",
+  "result": { ... },
+  "connector": "gmail"
+}
+```
+
+### POST /execute-confirm
+
+Confirm execution completion (post-execution verification).
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Replay Prevention | Yes |
+| Ledger Entry | `confirm` |
+
+### POST /receipt
+
+Generate a cryptographic receipt for a completed intent.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Replay Prevention | Yes |
+| Ledger Entry | `receipt` |
+
+**Response (200):**
+```json
+{
+  "receipt_id": "uuid-v4",
+  "intent_id": "uuid-v4",
+  "hash_chain": {
+    "intent_hash": "sha256-hex",
+    "governance_hash": "sha256-hex",
+    "authorization_hash": "sha256-hex",
+    "execution_hash": "sha256-hex",
+    "receipt_hash": "sha256-hex"
+  },
+  "ledger_hash": "sha256-hex",
+  "previous_hash": "sha256-hex | GENESIS",
+  "signature": "hex-string",
+  "verification_method": "ed25519",
+  "status": "valid"
+}
+```
+
+### GET /intents
+
+List all intents with optional status filter.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+| Query Params | `status` (optional filter) |
+
+### GET /intent/:id
+
+Get a specific intent by ID with full pipeline state.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+
+### GET /ledger
+
+Return all ledger entries (hash-chained).
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+
+### GET /verify
+
+Verify the integrity of the entire ledger hash chain.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT |
+
+**Response (200):**
+```json
+{
+  "chain_valid": true,
+  "total_entries": 42,
+  "first_hash": "sha256-hex",
+  "last_hash": "sha256-hex",
+  "verified_at": "2026-03-31T20:00:00.000Z"
+}
+```
+
+### GET /health
+
+System health check (public, no auth required).
+
+| Field | Value |
+|-------|-------|
+| Auth Required | No |
+
+**Response (200):**
+```json
+{
+  "status": "operational",
+  "version": "2.7.0",
+  "uptime": 86400,
+  "governance": {
+    "constitution_loaded": true,
+    "policy_loaded": true,
+    "policy_version": "1.1"
+  },
+  "ledger": {
+    "total_entries": 42,
+    "chain_valid": true
+  },
+  "security": {
+    "ed25519_mode": "required",
+    "replay_prevention": true,
+    "registered_signers": 1
+  }
+}
+```
+
+---
+
+## 3. Public API v1 Endpoints
+
+All Public API v1 endpoints are mounted at `/api/v1/` and require API key authentication via the `X-API-Key` header. Rate limiting is enforced per API key.
+
+### Authentication
+
+All requests must include:
+```
+X-API-Key: <api-key>
+```
+
+API keys have scopes: `read`, `write`, `admin`.
+
+### Rate Limits
+
+| Scope | Limit |
+|-------|-------|
+| `read` | 100 requests/minute |
+| `write` | 30 requests/minute |
+| `admin` | 10 requests/minute |
+
+Rate limit headers are included in every response:
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 97
+X-RateLimit-Reset: 1743451260
+```
+
+### Endpoints
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| POST | `/api/v1/intents` | write | Submit a new intent |
+| GET | `/api/v1/intents` | read | List intents (with optional `?status=` filter) |
+| GET | `/api/v1/intents/:id` | read | Get intent by ID |
+| POST | `/api/v1/intents/:id/govern` | write | Evaluate intent against policy |
+| POST | `/api/v1/intents/:id/authorize` | admin | Authorize intent (approve/deny) |
+| POST | `/api/v1/intents/:id/execute` | admin | Execute authorized intent |
+| POST | `/api/v1/intents/:id/confirm` | write | Confirm execution |
+| POST | `/api/v1/intents/:id/receipt` | read | Generate receipt |
+| GET | `/api/v1/ledger` | read | Get ledger entries |
+| GET | `/api/v1/verify` | read | Verify chain integrity |
+| GET | `/api/v1/health` | none | Health check (no auth required) |
+| GET | `/api/v1/docs` | none | OpenAPI documentation |
+
+### API Key Management
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/v1/keys` | JWT (owner) | Create a new API key |
+| GET | `/api/v1/keys` | JWT or API key | List all API keys |
+| GET | `/api/v1/keys/:key_id` | JWT or API key | Get API key details |
+| DELETE | `/api/v1/keys/:key_id` | JWT (owner) | Revoke an API key |
+
+**Create API Key (POST /api/v1/keys):**
+```json
+{
+  "name": "jordan-frontend",
+  "scopes": ["read", "write"],
+  "expires_in": "30d"
+}
+```
+
+**Response:**
+```json
+{
+  "key_id": "uuid-v4",
+  "api_key": "rio_v1_...",
+  "name": "jordan-frontend",
+  "scopes": ["read", "write"],
+  "created_at": "2026-03-31T20:00:00.000Z",
+  "expires_at": "2026-04-30T20:00:00.000Z"
+}
+```
+
+---
+
+## 4. Identity & Signer Management
+
+Mounted at `/api/signers/`. All endpoints require JWT authentication with `role=owner`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/signers/generate-keypair` | Generate Ed25519 keypair (private key returned ONCE) |
+| POST | `/api/signers/register` | Register an externally-generated public key |
+| GET | `/api/signers` | List all registered signers (public keys only) |
+| GET | `/api/signers/:signer_id` | Get a specific signer |
+| DELETE | `/api/signers/:signer_id` | Revoke a signer |
+
+### POST /api/signers/generate-keypair
+
+Generate a new Ed25519 keypair. The private key is returned exactly once and never stored on the server.
+
+**Request Body:**
+```json
+{
+  "signer_id": "brian-sovereign",
+  "display_name": "Brian's Sovereign Key",
+  "role": "owner"
+}
+```
+
+**Response (201):**
+```json
+{
+  "signer_id": "brian-sovereign",
+  "public_key_hex": "64-char-hex",
+  "private_key_hex": "128-char-hex (SAVE THIS — returned only once)",
+  "display_name": "Brian's Sovereign Key",
+  "role": "owner",
+  "created_at": "2026-03-31T20:00:00.000Z",
+  "warning": "Private key is returned ONCE. Store it securely."
+}
+```
+
+### POST /api/signers/register
+
+Register an externally-generated Ed25519 public key.
+
+**Request Body:**
+```json
+{
+  "signer_id": "brian-mobile",
+  "public_key_hex": "64-char-hex",
+  "display_name": "Brian's Mobile Key",
+  "role": "owner"
+}
+```
+
+---
+
+## 5. Key Backup & Recovery
+
+Mounted at `/api/key-backup/`. All endpoints require JWT authentication. The server stores only encrypted ciphertext — decryption requires the user's passphrase, which is never sent to the server.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/key-backup` | Store an encrypted key backup |
+| GET | `/api/key-backup/:signer_id` | Retrieve an encrypted backup |
+| GET | `/api/key-backup` | List all backups for the authenticated user |
+| DELETE | `/api/key-backup/:signer_id` | Delete a backup |
+
+### POST /api/key-backup
+
+**Request Body:**
+```json
+{
+  "signer_id": "brian-sovereign",
+  "public_key_hex": "64-char-hex",
+  "encrypted_key": "base64-encrypted-private-key",
+  "salt": "base64-salt",
+  "iv": "base64-iv",
+  "version": 1
+}
+```
+
+---
+
+## 6. Device Sync
+
+Mounted at `/api/sync/`. Provides full device state restoration.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/sync` | JWT | Full device sync (identity + key backup + ledger) |
+| GET | `/api/sync/health` | None | Lightweight ledger health check |
+
+### POST /api/sync
+
+Returns everything a device needs to restore full signing and governance capability.
+
+**Request Body:**
+```json
+{
+  "signer_id": "brian-sovereign",
+  "last_known_hash": "sha256-hex (for incremental sync)",
+  "ledger_limit": 500
+}
+```
+
+**Response (200):**
+```json
+{
+  "identity": {
+    "signer_id": "brian-sovereign",
+    "public_key_hex": "64-char-hex",
+    "status": "active",
+    "has_backup": true
+  },
+  "key_backup": {
+    "encrypted_key": "base64",
+    "salt": "base64",
+    "iv": "base64"
+  },
+  "ledger": {
+    "entries": [ ... ],
+    "total_count": 42,
+    "returned_count": 42,
+    "tip_hash": "sha256-hex"
+  },
+  "health": {
+    "chain_valid": true,
+    "entry_count": 42,
+    "tip_hash": "sha256-hex"
+  }
+}
+```
+
+### GET /api/sync/health
+
+Lightweight health check for drift detection (no auth required).
+
+**Response (200):**
+```json
+{
+  "chain_valid": true,
+  "entry_count": 42,
+  "tip_hash": "sha256-hex",
+  "checked_at": "2026-03-31T20:00:00.000Z"
+}
+```
+
+---
+
+## 7. Proxy Onboarding (v2.7.0)
+
+**Status:** PR #80 (pending merge)
+
+These endpoints are mounted at `/api/` and provide proxy user management. They are part of the v2.7.0 release.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/kill` | JWT + Ed25519 | Emergency kill switch — burns tokens, pauses proxy |
+| GET | `/api/sync` | JWT | Real-time state endpoint (replaces Drive-based sync) |
+| POST | `/api/onboard` | JWT | Create user with Ed25519 key + welcome receipt |
+
+### POST /api/kill
+
+Emergency kill switch with dual-factor authentication. Burns all active execution tokens and pauses the proxy.
+
+| Field | Value |
+|-------|-------|
+| Auth Required | JWT + Ed25519 (dual-factor) |
+| Latency Target | <20ms |
+| Ledger Entry | `kill_switch` |
+
+**Request Body:**
+```json
+{
+  "reason": "Suspicious activity detected",
+  "signer_id": "brian-sovereign",
+  "signature": "ed25519-hex-signature",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (200):**
+```json
+{
+  "status": "killed",
+  "tokens_burned": 3,
+  "proxy_paused": true,
+  "receipt": {
+    "receipt_id": "uuid-v4",
+    "action": "KILL_PROXY",
+    "ledger_hash": "sha256-hex"
+  },
+  "latency_ms": 17
+}
+```
+
+### GET /api/sync (Proxy State)
+
+Real-time system state endpoint. Returns full operational status.
+
+**Response (200):**
+```json
+{
+  "version": "2.7.0",
+  "status": "operational",
+  "proxy": {
+    "active_users": 1,
+    "paused": false
+  },
+  "intents": {
+    "total": 42,
+    "by_status": {
+      "submitted": 2,
+      "governed": 5,
+      "authorized": 3,
+      "executed": 30,
+      "receipted": 2
+    }
+  },
+  "ledger": {
+    "total_entries": 42,
+    "chain_valid": true,
+    "tip_hash": "sha256-hex"
+  },
+  "signers": {
+    "total": 1,
+    "active": 1
+  }
+}
+```
+
+### POST /api/onboard
+
+Create a new proxy user with Ed25519 key registration and welcome receipt.
+
+**Request Body:**
+```json
+{
+  "user_id": "new-user",
+  "display_name": "New User",
+  "email": "user@example.com",
+  "role": "user",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Response (201):**
+```json
+{
+  "user_id": "new-user",
+  "signer_id": "new-user",
+  "public_key_hex": "64-char-hex",
+  "private_key_hex": "128-char-hex (SAVE THIS — returned only once)",
+  "welcome_receipt": {
+    "receipt_id": "uuid-v4",
+    "action": "USER_ONBOARD",
+    "ledger_hash": "sha256-hex"
+  }
+}
+```
+
+---
+
+## 8. Observability
+
+### GET /health (Root)
+
+Public health check endpoint. No authentication required.
+
+### GET /api/v1/health
+
+Public API v1 health check. No authentication required.
+
+### GET /api/sync/health
+
+Lightweight ledger health for drift detection. No authentication required.
+
+---
+
+## 9. Authentication Methods
+
+The gateway supports multiple authentication methods, applied at different layers:
+
+| Method | Layer | Usage |
+|--------|-------|-------|
+| JWT Bearer Token | Core pipeline, Signer management, Key backup, Sync | `Authorization: Bearer <token>` |
+| API Key | Public API v1 | `X-API-Key: <key>` |
+| Ed25519 Signature | Authorization, Kill switch | Inline `signature` + `signer_id` in request body |
+| Dual-Factor (JWT + Ed25519) | Kill switch | Both JWT header and Ed25519 signature in body |
+
+### Replay Prevention
+
+All POST endpoints enforce replay prevention via:
+- `request_timestamp`: Must be within 5-minute window
+- `request_nonce`: Must be unique (UUID v4)
+
+Requests missing these fields or with expired timestamps are rejected.
+
+### Token Burn
+
+Authorization produces a single-use execution token. The token:
+- Has a 5-minute TTL
+- Is consumed (burned) on first use
+- Cannot be replayed
+- Is bound to a specific intent_id
+
+---
+
+## 10. Error Responses
+
+All error responses follow a consistent format:
+
+```json
+{
+  "error": "Human-readable error message",
+  "hint": "Actionable suggestion for resolution",
+  "code": "ERROR_CODE"
+}
+```
+
+### Common Error Codes
+
+| HTTP Status | Code | Meaning |
+|-------------|------|---------|
+| 400 | `INVALID_REQUEST` | Missing or malformed request body |
+| 401 | `UNAUTHORIZED` | Missing or invalid JWT/API key |
+| 403 | `FORBIDDEN` | Insufficient permissions or role |
+| 403 | `SIGNATURE_REQUIRED` | Ed25519 signature required but not provided |
+| 403 | `SIGNATURE_INVALID` | Ed25519 signature verification failed |
+| 404 | `NOT_FOUND` | Intent or resource not found |
+| 409 | `REPLAY_DETECTED` | Duplicate nonce or expired timestamp |
+| 409 | `TOKEN_BURNED` | Execution token already consumed |
+| 429 | `RATE_LIMITED` | API rate limit exceeded |
+| 500 | `INTERNAL_ERROR` | Server error |
+
+---
+
+## Appendix: Endpoint Summary
+
+| # | Method | Path | Auth | Description |
+|---|--------|------|------|-------------|
+| 1 | POST | `/login` | None | Authenticate, get JWT |
+| 2 | GET | `/whoami` | JWT | Current user identity |
+| 3 | POST | `/intent` | JWT* | Submit intent |
+| 4 | POST | `/govern` | JWT | Evaluate against policy |
+| 5 | POST | `/authorize` | JWT + Ed25519 | Approve/deny intent |
+| 6 | POST | `/execute` | JWT + Token | Execute with single-use token |
+| 7 | POST | `/execute-confirm` | JWT | Confirm execution |
+| 8 | POST | `/receipt` | JWT | Generate receipt |
+| 9 | GET | `/ledger` | JWT | List ledger entries |
+| 10 | GET | `/verify` | JWT | Verify chain integrity |
+| 11 | GET | `/health` | None | System health |
+| 12 | GET | `/intents` | JWT | List intents |
+| 13 | GET | `/intent/:id` | JWT | Get intent detail |
+| 14 | POST | `/api/v1/intents` | API Key | Submit intent (v1) |
+| 15 | GET | `/api/v1/intents` | API Key | List intents (v1) |
+| 16 | GET | `/api/v1/intents/:id` | API Key | Get intent (v1) |
+| 17 | POST | `/api/v1/intents/:id/govern` | API Key | Govern intent (v1) |
+| 18 | POST | `/api/v1/intents/:id/authorize` | API Key | Authorize intent (v1) |
+| 19 | POST | `/api/v1/intents/:id/execute` | API Key | Execute intent (v1) |
+| 20 | POST | `/api/v1/intents/:id/confirm` | API Key | Confirm execution (v1) |
+| 21 | POST | `/api/v1/intents/:id/receipt` | API Key | Generate receipt (v1) |
+| 22 | GET | `/api/v1/ledger` | API Key | Get ledger (v1) |
+| 23 | GET | `/api/v1/verify` | API Key | Verify chain (v1) |
+| 24 | GET | `/api/v1/health` | None | Health check (v1) |
+| 25 | GET | `/api/v1/docs` | None | OpenAPI docs |
+| 26 | POST | `/api/v1/keys` | JWT | Create API key |
+| 27 | GET | `/api/v1/keys` | JWT/API Key | List API keys |
+| 28 | GET | `/api/v1/keys/:key_id` | JWT/API Key | Get API key |
+| 29 | DELETE | `/api/v1/keys/:key_id` | JWT | Revoke API key |
+| 30 | POST | `/api/signers/generate-keypair` | JWT (owner) | Generate Ed25519 keypair |
+| 31 | POST | `/api/signers/register` | JWT (owner) | Register external public key |
+| 32 | GET | `/api/signers` | JWT | List signers |
+| 33 | GET | `/api/signers/:signer_id` | JWT | Get signer |
+| 34 | DELETE | `/api/signers/:signer_id` | JWT (owner) | Revoke signer |
+| 35 | POST | `/api/key-backup` | JWT | Store encrypted backup |
+| 36 | GET | `/api/key-backup/:signer_id` | JWT | Retrieve backup |
+| 37 | GET | `/api/key-backup` | JWT | List backups |
+| 38 | DELETE | `/api/key-backup/:signer_id` | JWT | Delete backup |
+| 39 | POST | `/api/sync` | JWT | Full device sync |
+| 40 | GET | `/api/sync/health` | None | Ledger health check |
+| 41 | POST | `/api/kill` | JWT + Ed25519 | Kill switch (v2.7.0) |
+| 42 | GET | `/api/sync` (proxy) | JWT | Proxy state (v2.7.0) |
+| 43 | POST | `/api/onboard` | JWT | User onboarding (v2.7.0) |
+
+*JWT optional for `/intent` — unauthenticated submissions are accepted but flagged.

--- a/docs/ARCHITECTURE_v2.7.md
+++ b/docs/ARCHITECTURE_v2.7.md
@@ -1,0 +1,313 @@
+# RIO System Architecture — v2.7.0
+
+**Date:** 2026-03-31
+**Author:** Romney (Manus Agent)
+**Status:** Active Development
+**Production:** v2.6.0 at https://rio-gateway.onrender.com
+**Development:** v2.7.0 (proxy onboarding + policy config pending merge)
+
+---
+
+## 1. System Overview
+
+RIO (Relational Intent Orchestration) is a governance-first intent execution gateway. It sits between AI agents, humans, and real-world actions. Every action is authorized, executed, verified, recorded, and used to improve future decisions.
+
+The system enforces a **fail-closed architecture**: nothing executes unless explicitly approved through the governance pipeline. The default state is denial.
+
+---
+
+## 2. Core Invariants
+
+These invariants are structural, not advisory. They cannot be overridden by configuration.
+
+| # | Invariant | Enforcement |
+|---|-----------|-------------|
+| 1 | No action executes without governance evaluation | Pipeline stage gate: `govern` must precede `authorize` |
+| 2 | No execution without human authorization | `authorize` stage requires valid approval record |
+| 3 | Execution tokens are single-use | Token burn on first use; replay returns 409 |
+| 4 | Ledger is append-only | No UPDATE or DELETE on ledger table; hash chain validates integrity |
+| 5 | Hash chain is contiguous | Each entry's `prev_hash` must equal the preceding entry's `hash` |
+| 6 | Ed25519 signatures bind identity to decisions | When `ED25519_MODE=required`, unsigned authorizations are rejected |
+| 7 | Replay prevention on all mutations | `request_timestamp` + `request_nonce` validated on every POST |
+| 8 | Three-Power Separation | Observer, Governor, and Executor cannot cross boundaries |
+
+---
+
+## 3. Pipeline Architecture
+
+The governance pipeline processes intents through 7 sequential stages:
+
+```
+┌──────────┐   ┌──────────┐   ┌───────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+│  SUBMIT  │──►│  GOVERN  │──►│ AUTHORIZE │──►│ EXECUTE  │──►│ CONFIRM  │──►│ RECEIPT  │──►│  LEDGER  │
+│          │   │          │   │           │   │          │   │          │   │          │   │          │
+│ Intake + │   │ Policy   │   │ Human     │   │ Token    │   │ Post-    │   │ Hash     │   │ Append-  │
+│ normalize│   │ evaluate │   │ approval  │   │ burn +   │   │ execution│   │ chain +  │   │ only     │
+│          │   │          │   │ + Ed25519  │   │ dispatch │   │ verify   │   │ sign     │   │ store    │
+└──────────┘   └──────────┘   └───────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘
+     │              │               │               │               │              │              │
+     ▼              ▼               ▼               ▼               ▼              ▼              ▼
+  Ledger         Ledger          Ledger          Ledger          Ledger         Ledger         Ledger
+  (submit)       (govern)        (authorize)     (execute)       (confirm)      (receipt)      (chain)
+```
+
+Each stage appends an entry to the hash-chained ledger. The pipeline is strictly sequential — no stage can be skipped.
+
+---
+
+## 4. Three-Power Separation
+
+The system separates governance authority into three independent powers:
+
+### Observer (Mantis)
+
+The observation layer. Receives raw intents, normalizes them, attaches metadata, performs advisory risk classification, and forwards to the Governor.
+
+**Capabilities:** Intent reception, format normalization, metadata attachment, advisory risk classification, replay prevention, ledger logging (submit entries).
+
+**Constraints:** Cannot approve or deny. Cannot execute. Cannot hold API keys. Cannot modify intents after normalization.
+
+**Implementation:** `gateway/governance/intake.mjs`, `gateway/governance/intents.mjs`, `gateway/routes/index.mjs` (POST /intent)
+
+### Governor (Policy Engine)
+
+The decision layer. Evaluates intents against the constitution and policy. Determines risk level and whether human authorization is required.
+
+**Capabilities:** Policy evaluation, risk classification, approval routing, threshold enforcement, action classification.
+
+**Constraints:** Cannot execute actions. Cannot access connectors. Cannot modify the ledger (only append governance decisions). Cannot override human decisions.
+
+**Implementation:** `gateway/governance/policy.mjs`, `gateway/governance/config.mjs`, `gateway/routes/index.mjs` (POST /govern)
+
+### Executor (Connector Layer)
+
+The action layer. Dispatches authorized intents to target systems using single-use execution tokens.
+
+**Capabilities:** Token validation, connector dispatch, result capture, execution confirmation.
+
+**Constraints:** Cannot approve intents. Cannot modify governance decisions. Cannot bypass token burn. Cannot execute without a valid, unexpired token.
+
+**Implementation:** `gateway/routes/index.mjs` (POST /execute, POST /execute-confirm)
+
+See `spec/THREE_POWER_SEPARATION.md` for the full specification.
+
+---
+
+## 5. Security Architecture
+
+### 5.1 Authentication Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Request Arrives                        │
+├─────────────────────────────────────────────────────────┤
+│ Layer 1: Replay Prevention                               │
+│   request_timestamp (5-min window) + request_nonce       │
+├─────────────────────────────────────────────────────────┤
+│ Layer 2: Identity Authentication                         │
+│   JWT Bearer Token  OR  API Key (X-API-Key header)       │
+├─────────────────────────────────────────────────────────┤
+│ Layer 3: Cryptographic Signature (when required)         │
+│   Ed25519 signature with registered signer_id            │
+├─────────────────────────────────────────────────────────┤
+│ Layer 4: Token Burn (execution only)                     │
+│   Single-use execution_token consumed on dispatch        │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Ed25519 Identity Binding
+
+Every human authority in the system is bound to an Ed25519 keypair:
+
+- **Key generation:** Server generates keypair, returns private key ONCE, stores only public key
+- **External registration:** Users can register externally-generated public keys
+- **Signature verification:** Authorization requests include `signer_id` + `signature`; server verifies against registered public key
+- **Key backup:** Encrypted private key backups stored on server (server never sees plaintext)
+- **Key revocation:** Signers can be revoked, immediately invalidating their authority
+
+### 5.3 Token Burn
+
+Authorization produces a single-use execution token:
+- 5-minute TTL
+- Bound to specific intent_id
+- Consumed on first use (burned)
+- Cannot be replayed or reused
+- Stored in memory with automatic expiry
+
+### 5.4 Hash Chain Integrity
+
+The ledger maintains a contiguous SHA-256 hash chain:
+- Each entry includes `hash` (SHA-256 of entry content) and `prev_hash` (hash of preceding entry)
+- First entry uses `prev_hash = "GENESIS"`
+- Chain integrity can be verified at any time via `GET /verify`
+- Serialization: deterministic JSON (keys sorted alphabetically, no whitespace, UTF-8)
+
+---
+
+## 6. Data Architecture
+
+### 6.1 PostgreSQL Tables
+
+| Table | Purpose | Type |
+|-------|---------|------|
+| `ledger_entries` | Hash-chained governance audit trail | Append-only |
+| `authorized_signers` | Ed25519 public key registry | CRUD (with revocation) |
+| `proxy_users` | Proxy user accounts (v2.7.0) | CRUD |
+
+### 6.2 In-Memory Stores
+
+| Store | Purpose | Persistence |
+|-------|---------|-------------|
+| `intents` | Active intent pipeline state | Memory (lost on restart) |
+| `execution_tokens` | Single-use tokens with TTL | Memory (auto-expire) |
+| `api_keys` | API key registry | Memory (lost on restart) |
+| `key_backups` | Encrypted key backup storage | Memory (lost on restart) |
+| `nonce_cache` | Replay prevention nonces | Memory (auto-expire) |
+
+### 6.3 Ledger Entry Schema
+
+```json
+{
+  "entry_id": "auto-increment",
+  "intent_id": "uuid-v4",
+  "action": "submit | govern | authorize | execute | confirm | receipt | kill_switch | onboard",
+  "hash": "sha256-hex",
+  "prev_hash": "sha256-hex | GENESIS",
+  "timestamp": "ISO-8601",
+  "data": { ... }
+}
+```
+
+---
+
+## 7. Module Map
+
+```
+gateway/
+├── server.mjs                    # Express app, route mounting, middleware
+├── config/
+│   └── rio/
+│       ├── RIO_CONSTITUTION.json # System constitution
+│       └── RIO_POLICY.json       # Governance policy v1.1
+├── governance/
+│   ├── config.mjs                # Config loader (fail-closed)
+│   ├── intake.mjs                # Intent normalization
+│   ├── intents.mjs               # Intent CRUD + pipeline state
+│   ├── policy.mjs                # Policy evaluation engine
+│   └── proxy-store.mjs           # Proxy user management (v2.7.0)
+├── ledger/
+│   └── ledger-pg.mjs             # PostgreSQL append-only ledger
+├── routes/
+│   ├── index.mjs                 # Core pipeline routes (7 stages)
+│   ├── api-v1.mjs                # Public API v1 (API key auth + rate limiting)
+│   ├── signers.mjs               # Ed25519 signer management
+│   ├── key-backup.mjs            # Encrypted key backup
+│   ├── sync.mjs                  # Device sync + ledger health
+│   └── proxy.mjs                 # Kill switch, sync, onboard (v2.7.0)
+├── security/
+│   ├── oauth.mjs                 # JWT authentication middleware
+│   ├── ed25519.mjs               # Ed25519 key generation + signing
+│   ├── identity-binding.mjs      # Signer registry (register, list, revoke)
+│   ├── replay-prevention.mjs     # Timestamp + nonce validation
+│   └── token-manager.mjs         # Single-use execution token management (v2.7.0)
+└── test_*.mjs                    # Test suites
+```
+
+---
+
+## 8. Deployment Architecture
+
+### 8.1 Current (Render.com)
+
+```
+┌─────────────────────────────────────────────┐
+│              Render.com                       │
+│                                               │
+│  ┌─────────────────┐   ┌──────────────────┐  │
+│  │  Gateway Service │   │   PostgreSQL DB   │  │
+│  │  (Docker)        │──►│   (Managed)       │  │
+│  │  Port 10000      │   │                    │  │
+│  │  v2.6.0          │   │  - ledger_entries  │  │
+│  │                   │   │  - auth_signers   │  │
+│  └─────────────────┘   └──────────────────┘  │
+│           │                                    │
+│           ▼                                    │
+│  https://rio-gateway.onrender.com              │
+└─────────────────────────────────────────────┘
+```
+
+### 8.2 Planned (Azure — Manny's Pipeline)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                        Azure                              │
+│                                                           │
+│  Outlook → Power Automate → Service Bus → Gateway         │
+│                                                           │
+│  ┌──────────┐   ┌────────────┐   ┌──────────────────┐   │
+│  │ Outlook  │──►│   Power    │──►│   Service Bus    │   │
+│  │ Inbox    │   │ Automate   │   │   Queue          │   │
+│  └──────────┘   └────────────┘   └──────────────────┘   │
+│                                          │                │
+│                                          ▼                │
+│                                  ┌──────────────┐        │
+│                                  │   Gateway    │        │
+│                                  │   (Azure)    │        │
+│                                  └──────────────┘        │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 9. Version History
+
+| Version | Date | Key Changes |
+|---------|------|-------------|
+| 2.0.0 | 2026-03-25 | PostgreSQL ledger, hash chain, JWT auth |
+| 2.1.0 | 2026-03-26 | Governance pipeline (7 stages), policy engine |
+| 2.2.0 | 2026-03-27 | Execution tokens, token burn, replay prevention |
+| 2.3.0 | 2026-03-27 | Receipt generation, hash chain verification |
+| 2.4.0 | 2026-03-28 | Ed25519 identity binding (WS-010) |
+| 2.5.0 | 2026-03-28 | Key backup, device sync, ledger resync |
+| 2.6.0 | 2026-03-29 | Public API v1 (WS-012), API key auth, rate limiting |
+| 2.7.0 | 2026-03-31 | Proxy onboarding (kill, sync, onboard), policy config |
+
+---
+
+## 10. Team Responsibilities
+
+| Team Member | Role | Owns |
+|-------------|------|------|
+| Romney | Backend Builder | Gateway, connectors, ledger, security, API, specs |
+| Manny | Coordinator | Azure infrastructure, Power Automate, Service Bus |
+| Jordan | Frontend Builder | ONE App dashboard, onboarding wizard, visualizations |
+| Damon | DevOps/Architect | Deployment, CI/CD, infrastructure architecture |
+| Andrew | Analyst/Auditor | Audit, compliance, verification |
+| Brian | Owner/Authority | Sovereign signer, final approval authority |
+
+---
+
+## 11. Open PRs and Pending Work
+
+| PR | Branch | Description | Status |
+|----|--------|-------------|--------|
+| #78 | `feature/policy-config-agents` | Policy config + agent recognition + signer_id fix | Pending merge |
+| #80 | `feature/proxy-onboarding` | Kill switch, sync, onboard endpoints | Pending merge |
+| — | `docs/spec-and-architecture` | Three-Power Separation spec, Mantis component, API catalog, architecture docs | In progress |
+
+---
+
+## 12. References
+
+| Document | Location |
+|----------|----------|
+| Three-Power Separation Spec | `spec/THREE_POWER_SEPARATION.md` |
+| Mantis Component Definition | `spec/MANTIS_COMPONENT.md` |
+| Receipt Specification v2.1 | `spec/Receipt_Specification_v2.1.json` |
+| API Endpoint Catalog | `docs/API_CATALOG_v2.7.md` |
+| Intake Schema | `spec/intake-schema.json` |
+| Core Spec v1 | `spec/core-spec-v1.json` |
+| Policy v1.0 | `spec/policy-v1.0.json` |
+| Gateway Wiring (Jordan) | `docs/GATEWAY_WIRING.md` |
+| Deployment Guide | `docs/DEPLOYMENT_GUIDE.md` |
+| White Paper (Formal) | `docs/RIO_White_Paper_Formal.md` |

--- a/spec/MANTIS_COMPONENT.md
+++ b/spec/MANTIS_COMPONENT.md
@@ -1,0 +1,197 @@
+# Mantis Component Definition
+
+**Version:** 1.0
+**Status:** Active
+**Spec ID:** RIO-COMP-MANTIS-001
+**Date:** 2026-03-31
+
+---
+
+## 1. Identity
+
+**Name:** Mantis
+**Type:** Governance Observer + Risk Assessor
+**Role:** The Observer power within the Three-Power Separation architecture.
+**Position:** First stage of the RIO governance pipeline — sits between intent sources and the Governor.
+
+---
+
+## 2. Purpose
+
+Mantis is the observation layer of the RIO governance runtime. It receives raw intents from any source, normalizes them into the Intake Schema v1 format, attaches ingestion metadata, performs advisory risk classification, and forwards the structured intent envelope to the Governor for binding evaluation.
+
+Mantis sees everything. Mantis decides nothing. Mantis acts on nothing.
+
+---
+
+## 3. Capabilities
+
+| Capability | Description | Boundary |
+|------------|-------------|----------|
+| **Intent Reception** | Accept intents from any authenticated source (API, email, Service Bus, frontend, webhook) | Read-only access to raw input |
+| **Format Normalization** | Transform heterogeneous input formats into canonical `IntentEnvelope` (Intake Schema v1) | Write to intents table only |
+| **Metadata Attachment** | Add `ingestion_source`, `ingestion_timestamp`, `source_channel`, `request_id` to every intent | Append-only metadata fields |
+| **Advisory Risk Classification** | Perform preliminary risk assessment based on action type, target, and historical patterns | Non-binding; Governor makes final determination |
+| **Replay Prevention** | Validate `request_timestamp` and `request_nonce` to prevent duplicate submissions | Reject duplicates, log attempts |
+| **Ledger Logging** | Append `submit` entry to the hash-chained ledger for every received intent | Append-only; cannot modify existing entries |
+
+---
+
+## 4. Constraints
+
+Mantis operates under strict boundary constraints defined by the Three-Power Separation spec (`RIO-SPEC-TPS-001`):
+
+| Constraint | Enforcement |
+|------------|-------------|
+| Cannot approve or deny intents | No access to governance decision functions |
+| Cannot modify intent parameters after normalization | Intent is immutable once assigned an ID |
+| Cannot access execution connectors | No imports from `execution/` modules |
+| Cannot hold API keys or OAuth tokens | Keys stored only in Executor environment |
+| Cannot override Governor verdicts | No access to governance state mutation |
+| Cannot bypass replay prevention | Middleware runs before Mantis processing |
+
+---
+
+## 5. Interface Contract
+
+### 5.1 Input (Raw Intent)
+
+Mantis accepts intents in multiple formats and normalizes them:
+
+**Direct API (POST /intent):**
+```json
+{
+  "action": "send_email",
+  "agent_id": "manus",
+  "parameters": {
+    "to": "recipient@example.com",
+    "subject": "Test",
+    "body": "Hello"
+  },
+  "confidence": 95,
+  "target_environment": "production",
+  "request_timestamp": "2026-03-31T20:00:00.000Z",
+  "request_nonce": "uuid-v4"
+}
+```
+
+**Email Intent (via Service Bus):**
+```json
+{
+  "intent": "send_sms",
+  "parameters": {
+    "to": "+18015551234",
+    "message": "Test governed action"
+  },
+  "risk_level": "low",
+  "requires_approval": false,
+  "requested_by": "Brian",
+  "timestamp": "2026-03-31T20:00:00.000Z"
+}
+```
+
+### 5.2 Output (IntentEnvelope)
+
+After normalization, Mantis produces:
+
+```json
+{
+  "intent_id": "uuid-v4",
+  "action": "send_email",
+  "agent_id": "manus",
+  "parameters": { ... },
+  "confidence": 95,
+  "target_environment": "production",
+  "identity": {
+    "subject": "brian.k.rasmussen",
+    "method": "jwt"
+  },
+  "ingestion": {
+    "source": "api",
+    "channel": "POST /intent",
+    "timestamp": "2026-03-31T20:00:00.000Z",
+    "request_id": "uuid-v4"
+  },
+  "status": "submitted",
+  "hash": "sha256-of-intent-payload"
+}
+```
+
+### 5.3 Ledger Entry
+
+Every intent submission produces a ledger entry:
+
+```json
+{
+  "entry_id": 1,
+  "intent_id": "uuid-v4",
+  "action": "submit",
+  "hash": "sha256-of-entry",
+  "prev_hash": "sha256-of-previous-entry",
+  "timestamp": "2026-03-31T20:00:00.000Z",
+  "data": {
+    "agent_id": "manus",
+    "action_type": "send_email",
+    "target": "production",
+    "ingestion_source": "api"
+  }
+}
+```
+
+---
+
+## 6. Implementation Mapping
+
+| Component | File | Function |
+|-----------|------|----------|
+| Intake normalization | `gateway/governance/intake.mjs` | `normalizeLegacy()`, `normalizeV1()` |
+| Intent storage | `gateway/governance/intents.mjs` | `createIntent()`, `getIntent()`, `updateIntent()` |
+| Replay prevention | `gateway/security/replay-prevention.mjs` | `replayPreventionMiddleware()` |
+| Ledger append | `gateway/ledger/ledger-pg.mjs` | `appendEntry()` |
+| Route handler | `gateway/routes/index.mjs` | `POST /intent` |
+| Public API handler | `gateway/routes/api-v1.mjs` | `POST /api/v1/intents` |
+
+---
+
+## 7. Ingestion Sources
+
+Mantis is designed to accept intents from any authenticated channel. Each source is recorded in the `ingestion.source` field of the IntentEnvelope.
+
+| Source | Channel | Status | Implementation |
+|--------|---------|--------|----------------|
+| Direct API | `POST /intent` | Active | `routes/index.mjs` |
+| Public API v1 | `POST /api/v1/intents` | Active | `routes/api-v1.mjs` |
+| Onboarding | `POST /api/onboard` | Active | `routes/proxy.mjs` |
+| Email | Outlook → Power Automate → Service Bus | In Progress | Manny's pipeline |
+| SMS | Twilio webhook | Planned | Damon's connector |
+| Webhook | `POST /api/v1/webhook` | Planned | Future |
+| Voice | Speech-to-text → intent | Planned | Future |
+
+---
+
+## 8. Monitoring
+
+Mantis contributes to the following health indicators:
+
+| Metric | Source | Meaning |
+|--------|--------|---------|
+| `intents.total` | `GET /api/sync` | Total intents received |
+| `intents.by_status` | `GET /api/sync` | Breakdown by pipeline stage |
+| `ledger.total_entries` | `GET /api/sync` | Total ledger entries (includes Mantis submissions) |
+| `replay_prevention.active` | `GET /health` | Whether replay prevention is enforcing |
+
+---
+
+## 9. Relationship to Other Components
+
+```
+                    ┌─────────────┐
+  Intent Sources ──►│   MANTIS    │──► Governor ──► Executor ──► Ledger
+  (API, Email,      │ (Observer)  │
+   SMS, Webhook)    └─────────────┘
+                          │
+                          ▼
+                    Ledger (submit entry)
+```
+
+Mantis feeds the Governor. The Governor feeds the Executor. The Executor feeds the Ledger. No component can reach backward in this chain. The separation is structural, not advisory.

--- a/spec/Receipt_Specification_v2.1.json
+++ b/spec/Receipt_Specification_v2.1.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RIO Receipt Protocol Specification",
+  "version": "2.1.0",
+  "description": "Defines the data structures that form the complete chain of custody for a governed AI action under the RIO protocol. v2.1 adds ingestion provenance tracking and Ed25519 identity binding to receipts.",
+  "author": "Brian Kent Rasmussen",
+  "repository": "https://github.com/bkr1297-RIO/rio-system",
+  "changelog": {
+    "2.1.0": {
+      "date": "2026-03-31",
+      "changes": [
+        "Added 'ingestion' object to ActionRequest for source provenance tracking",
+        "Added 'identity_binding' object to Receipt for Ed25519 signer proof",
+        "Added 'kill_switch' receipt type to Receipt status enum",
+        "Added 'onboard' receipt type for welcome receipts",
+        "Preserved full backward compatibility with v2.0.0"
+      ]
+    }
+  },
+  "definitions": {
+    "ActionRequest": {
+      "description": "An immutable record of a proposed action submitted by an AI agent or upstream system. Once created, the request cannot be modified.",
+      "type": "object",
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for this action request."
+        },
+        "action_type": {
+          "type": "string",
+          "description": "The type of action being requested.",
+          "examples": ["send_email", "send_sms", "create_pr", "transfer_funds", "create_event", "write_file", "KILL_PROXY"]
+        },
+        "requested_by": {
+          "type": "string",
+          "description": "Identifier of the AI agent or system that submitted this request."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target system or resource the action will affect.",
+          "examples": ["gmail", "github", "google_drive", "slack", "outlook", "twilio", "payment_processor"]
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Action-specific parameters. Structure varies by action_type."
+        },
+        "risk_level": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "critical"],
+          "description": "Assessed risk level of the proposed action."
+        },
+        "context": {
+          "type": "string",
+          "description": "Optional free-text context explaining why this action is being requested."
+        },
+        "ingestion": {
+          "type": "object",
+          "description": "Provenance metadata recording how this intent entered the system. Added in v2.1.",
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["api", "email", "sms", "webhook", "frontend", "service_bus", "onboard", "kill_switch", "internal"],
+              "description": "The channel through which this intent was received."
+            },
+            "channel": {
+              "type": "string",
+              "description": "Specific endpoint or integration path.",
+              "examples": ["POST /intent", "POST /api/v1/intents", "outlook-power-automate", "twilio-webhook", "POST /api/onboard"]
+            },
+            "source_message_id": {
+              "type": "string",
+              "description": "Original message ID from the source system (e.g., Outlook message ID, Twilio SID)."
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 UTC timestamp of when the intent was received by the gateway."
+            }
+          },
+          "required": ["source", "channel", "timestamp"]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when this request was created."
+        }
+      },
+      "required": ["request_id", "action_type", "requested_by", "target", "parameters", "risk_level", "created_at"]
+    },
+    "AIRecommendation": {
+      "description": "The AI system's evaluation of an ActionRequest against the active policy context.",
+      "type": "object",
+      "properties": {
+        "recommendation_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for this recommendation."
+        },
+        "request_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The request_id of the ActionRequest being evaluated."
+        },
+        "recommended_action": {
+          "type": "string",
+          "enum": ["proceed", "block", "escalate"],
+          "description": "The AI's recommendation for how to handle this request."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Confidence score for the recommendation (0.0 = no confidence, 1.0 = full confidence)."
+        },
+        "reasoning": {
+          "type": "string",
+          "description": "Explanation of the factors considered in making this recommendation."
+        },
+        "unknowns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit declaration of assumptions or unknowns that affect confidence."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when this recommendation was generated."
+        }
+      },
+      "required": ["recommendation_id", "request_id", "recommended_action", "confidence", "reasoning", "created_at"]
+    },
+    "ApprovalRecord": {
+      "description": "A cryptographically signed, time-limited authorization from a human authority. Each approval is bound to a specific request_id and can only be used once.",
+      "type": "object",
+      "properties": {
+        "approval_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for this approval record."
+        },
+        "request_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The request_id of the ActionRequest being authorized."
+        },
+        "approver_id": {
+          "type": "string",
+          "description": "Identifier of the human who issued this approval. Derived from authenticated session, not client-supplied."
+        },
+        "approver_role": {
+          "type": "string",
+          "description": "The organizational role of the approver at the time of approval.",
+          "examples": ["account_owner", "system_admin", "compliance_officer"]
+        },
+        "signer_id": {
+          "type": "string",
+          "description": "The registered signer ID used for Ed25519 signature. Added in v2.1."
+        },
+        "approval_status": {
+          "type": "string",
+          "enum": ["approved", "denied", "revoked", "expired"],
+          "description": "The outcome of the human authorization decision."
+        },
+        "approved_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when the human issued this approval."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when this approval expires. Default TTL: 300 seconds."
+        },
+        "auth_method": {
+          "type": "string",
+          "enum": ["password", "mfa_totp", "mfa_hardware_key", "biometric", "oauth2", "api_key_signed", "ed25519"],
+          "description": "The authentication method used to verify the approver's identity."
+        },
+        "conditions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional conditions or constraints attached to the approval."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Cryptographic signature over the canonical approval payload."
+        },
+        "signature_algorithm": {
+          "type": "string",
+          "enum": ["hmac_sha256", "ecdsa_secp256k1", "rsa_pss_sha256", "ed25519"],
+          "description": "The algorithm used to generate the signature."
+        }
+      },
+      "required": ["approval_id", "request_id", "approver_id", "approval_status", "approved_at", "auth_method", "signature", "signature_algorithm"]
+    },
+    "ExecutionRecord": {
+      "description": "The record of what was actually executed against the target system.",
+      "type": "object",
+      "properties": {
+        "execution_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for this execution record."
+        },
+        "request_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The request_id of the original ActionRequest."
+        },
+        "approval_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The approval_id of the ApprovalRecord that authorized this execution."
+        },
+        "executed_by": {
+          "type": "string",
+          "description": "Identifier of the system or service that performed the execution."
+        },
+        "executed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when the execution occurred."
+        },
+        "execution_status": {
+          "type": "string",
+          "enum": ["success", "failed", "partial", "rolled_back", "blocked"],
+          "description": "The outcome of the execution attempt."
+        },
+        "execution_token_id": {
+          "type": "string",
+          "description": "One-time token consumed during execution, proving authorization and preventing replay."
+        },
+        "result": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The result returned by the target system."
+        },
+        "connector": {
+          "type": "string",
+          "description": "The connector used to dispatch the action.",
+          "examples": ["gmail", "github", "google_drive", "slack", "outlook", "twilio"]
+        }
+      },
+      "required": ["execution_id", "request_id", "approval_id", "executed_by", "executed_at", "execution_status", "execution_token_id"]
+    },
+    "Receipt": {
+      "description": "The final, immutable record binding all preceding artifacts into a single signed document. Receipts form a hash-chained ledger. v2.1 adds identity_binding for Ed25519 signer proof.",
+      "type": "object",
+      "properties": {
+        "receipt_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for this receipt."
+        },
+        "receipt_type": {
+          "type": "string",
+          "enum": ["governed_action", "kill_switch", "onboard", "system"],
+          "description": "The type of receipt. Added in v2.1. 'governed_action' is the standard pipeline receipt. 'kill_switch' records emergency proxy shutdown. 'onboard' records new user welcome. 'system' records system-level events.",
+          "default": "governed_action"
+        },
+        "request_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The request_id of the original ActionRequest."
+        },
+        "recommendation_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The recommendation_id of the AIRecommendation."
+        },
+        "approval_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The approval_id of the ApprovalRecord."
+        },
+        "execution_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The execution_id of the ExecutionRecord."
+        },
+        "action_type": {
+          "type": "string",
+          "description": "The action type from the original request."
+        },
+        "requested_by": {
+          "type": "string",
+          "description": "The agent that requested the action."
+        },
+        "approver_id": {
+          "type": "string",
+          "description": "The human who approved the action."
+        },
+        "executed_by": {
+          "type": "string",
+          "description": "The system that executed the action."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp of when this receipt was generated."
+        },
+        "ingestion": {
+          "type": "object",
+          "description": "Provenance metadata from the original ActionRequest. Added in v2.1.",
+          "properties": {
+            "source": { "type": "string" },
+            "channel": { "type": "string" },
+            "source_message_id": { "type": "string" }
+          }
+        },
+        "identity_binding": {
+          "type": "object",
+          "description": "Ed25519 identity binding proof linking the approval to a registered signer. Added in v2.1.",
+          "properties": {
+            "signer_id": {
+              "type": "string",
+              "description": "The registered signer ID from the authorized_signers table."
+            },
+            "public_key_hex": {
+              "type": "string",
+              "description": "The Ed25519 public key (64-char hex) of the signer at the time of approval."
+            },
+            "signature_payload_hash": {
+              "type": "string",
+              "description": "SHA-256 hash of the canonical JSON payload that was signed."
+            },
+            "verification_method": {
+              "type": "string",
+              "enum": ["ed25519"],
+              "description": "The signature verification method used."
+            }
+          },
+          "required": ["signer_id", "public_key_hex", "signature_payload_hash", "verification_method"]
+        },
+        "hash_chain": {
+          "type": "object",
+          "properties": {
+            "intent_hash": { "type": "string", "description": "SHA-256 hash of the ActionRequest." },
+            "governance_hash": { "type": "string", "description": "SHA-256 hash of the governance decision." },
+            "authorization_hash": { "type": "string", "description": "SHA-256 hash of the ApprovalRecord." },
+            "execution_hash": { "type": "string", "description": "SHA-256 hash of the ExecutionRecord." },
+            "receipt_hash": { "type": "string", "description": "SHA-256 hash of this receipt (covers all preceding hashes)." }
+          },
+          "required": ["intent_hash", "governance_hash", "authorization_hash", "execution_hash", "receipt_hash"]
+        },
+        "ledger_hash": {
+          "type": "string",
+          "description": "SHA-256 hash of the canonical receipt content, used for ledger chain integrity."
+        },
+        "previous_hash": {
+          "type": "string",
+          "description": "The ledger_hash of the immediately preceding receipt. Value is 'GENESIS' for the first receipt in the chain."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Cryptographic signature over the canonical receipt content."
+        },
+        "verification_method": {
+          "type": "string",
+          "enum": ["hmac_sha256", "ecdsa_secp256k1", "rsa_pss_sha256", "ed25519"],
+          "description": "The signature algorithm used."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["valid", "tampered", "unverified"],
+          "description": "The verification status of this receipt."
+        }
+      },
+      "required": ["receipt_id", "request_id", "action_type", "requested_by", "created_at", "ledger_hash", "previous_hash", "status"]
+    }
+  },
+  "hash_specification": {
+    "algorithm": "SHA-256",
+    "serialization": "Deterministic JSON (keys sorted alphabetically, no whitespace, UTF-8 encoding)",
+    "genesis_value": "GENESIS",
+    "chain_order": ["intent_hash", "governance_hash", "authorization_hash", "execution_hash", "receipt_hash"]
+  },
+  "supported_signature_methods": [
+    "hmac_sha256",
+    "ecdsa_secp256k1",
+    "rsa_pss_sha256",
+    "ed25519"
+  ],
+  "ingestion_sources": {
+    "description": "Canonical list of ingestion source identifiers. Each intent entering the system must declare its source.",
+    "sources": [
+      { "id": "api", "description": "Direct API call via POST /intent or POST /api/v1/intents" },
+      { "id": "email", "description": "Email-originated intent via Outlook → Power Automate → Service Bus" },
+      { "id": "sms", "description": "SMS-originated intent via Twilio webhook" },
+      { "id": "webhook", "description": "Generic webhook ingestion" },
+      { "id": "frontend", "description": "Intent submitted from the Jordan dashboard UI" },
+      { "id": "service_bus", "description": "Azure Service Bus message" },
+      { "id": "onboard", "description": "User onboarding welcome receipt" },
+      { "id": "kill_switch", "description": "Emergency proxy shutdown" },
+      { "id": "internal", "description": "System-generated internal event" }
+    ]
+  }
+}

--- a/spec/THREE_POWER_SEPARATION.md
+++ b/spec/THREE_POWER_SEPARATION.md
@@ -1,0 +1,322 @@
+# Three-Power Separation Specification
+
+**Version:** 1.0
+**Status:** Active
+**Author:** Romney (RIO Engineering)
+**Date:** 2026-03-31
+**Spec ID:** RIO-SPEC-TPS-001
+
+---
+
+## 1. Purpose
+
+This document defines the structural separation of powers within the RIO governance runtime. The architecture enforces that no single component can both decide and act. Three distinct powers — **Observation**, **Governance**, and **Execution** — operate in isolation with defined boundaries, explicit handoff contracts, and cryptographic proof at every transition.
+
+This is not a design pattern. It is a structural invariant. If any component crosses its boundary, the system is in violation and must fail closed.
+
+---
+
+## 2. The Three Powers
+
+### 2.1 Observer (Power of Perception)
+
+**Responsibility:** Receive, normalize, and classify incoming intents. The Observer sees everything but decides nothing.
+
+**Boundary:** The Observer may read intent data, attach metadata (timestamps, source identifiers, risk classification hints), and forward normalized intents to the Governor. The Observer **must not** approve, deny, modify, or execute any intent.
+
+| Capability | Permitted | Prohibited |
+|------------|-----------|------------|
+| Receive raw intents from any source | Yes | — |
+| Normalize intent format (Intake Schema v1) | Yes | — |
+| Attach ingestion metadata (source, timestamp) | Yes | — |
+| Classify risk level (advisory, non-binding) | Yes | — |
+| Forward to Governor queue | Yes | — |
+| Approve or deny intents | — | Yes |
+| Modify intent parameters | — | Yes |
+| Access execution connectors | — | Yes |
+| Hold API keys or OAuth tokens | — | Yes |
+
+**Input contract:** Raw intent from any source (email, API, frontend, Service Bus).
+**Output contract:** Normalized `IntentEnvelope` forwarded to the governance queue.
+
+**Ingestion sources:**
+- `POST /intent` — Direct API submission
+- `POST /api/v1/intents` — Public API v1 submission
+- `POST /api/onboard` — Onboarding welcome intent
+- Email → Power Automate → Service Bus → Observer (Manny's pipeline)
+- Future: Webhook, SMS, voice
+
+### 2.2 Governor (Power of Decision)
+
+**Responsibility:** Evaluate intents against the active policy set and issue binding verdicts. The Governor decides but never acts.
+
+**Boundary:** The Governor may read the normalized intent, evaluate it against the constitution, policy, and role definitions, and produce a governance decision. The Governor **must not** execute actions, access external APIs, or modify the intent after evaluation.
+
+| Capability | Permitted | Prohibited |
+|------------|-----------|------------|
+| Read normalized intent | Yes | — |
+| Evaluate against RIO_CONSTITUTION.json | Yes | — |
+| Evaluate against RIO_POLICY.json | Yes | — |
+| Evaluate against role definitions | Yes | — |
+| Classify risk level (binding) | Yes | — |
+| Issue verdict: AUTO_APPROVE, REQUIRE_HUMAN, AUTO_DENY | Yes | — |
+| Record governance decision hash in ledger | Yes | — |
+| Execute actions | — | Yes |
+| Access OAuth tokens or API keys | — | Yes |
+| Modify intent parameters | — | Yes |
+| Override human denial | — | Yes |
+
+**Input contract:** `IntentEnvelope` from Observer.
+**Output contract:** `GovernanceDecision` containing verdict, risk level, policy violations, confidence score, and decision hash.
+
+**Verdicts:**
+
+| Verdict | Meaning | Next Step |
+|---------|---------|-----------|
+| `AUTO_APPROVE` | Intent is within pre-authorized boundaries | Proceed to Execution |
+| `REQUIRE_HUMAN` | Intent exceeds autonomous thresholds | Block until human authority issues signed approval |
+| `AUTO_DENY` | Intent violates hard policy constraint | Permanently blocked, logged in ledger |
+
+**Policy checks (evaluated in order):**
+1. Constitution compliance (hard constraints)
+2. Agent recognition (is the agent in scope?)
+3. Environment validation (is the target environment permitted?)
+4. Action classification (restricted, external_effect, irreversible)
+5. Confidence threshold (agent confidence >= policy minimum)
+6. Risk aggregation (combine all signals into final risk level)
+
+### 2.3 Executor (Power of Action)
+
+**Responsibility:** Carry out approved actions through external connectors. The Executor acts but never decides.
+
+**Boundary:** The Executor may receive a signed, approved intent and dispatch it to the appropriate connector (Gmail, Twilio, GitHub, etc.). The Executor **must not** evaluate policy, approve intents, or act without a valid authorization record.
+
+| Capability | Permitted | Prohibited |
+|------------|-----------|------------|
+| Receive authorized intent with valid approval | Yes | — |
+| Verify Ed25519 signature on approval | Yes | — |
+| Verify execution token is valid and unburned | Yes | — |
+| Dispatch action to external connector | Yes | — |
+| Record execution hash in ledger | Yes | — |
+| Generate cryptographic receipt | Yes | — |
+| Evaluate policy | — | Yes |
+| Approve or deny intents | — | Yes |
+| Execute without valid authorization | — | Yes |
+| Re-use burned execution tokens | — | Yes |
+| Modify intent parameters during execution | — | Yes |
+
+**Input contract:** `AuthorizedIntent` with valid Ed25519 signature, unburned execution token, matching intent ID.
+**Output contract:** `ExecutionResult` with connector response, execution hash, and receipt.
+
+**Pre-execution checks (all must pass):**
+1. Intent status is `authorized`
+2. Execution token exists and has not been burned
+3. Token matches the intent ID
+4. Ed25519 signature on authorization is valid (when mode = required)
+5. Signer public key is registered and not revoked
+
+---
+
+## 3. Boundary Enforcement
+
+### 3.1 Structural Isolation
+
+Each power is implemented as a separate module with no shared mutable state:
+
+| Power | Module(s) | Data Access |
+|-------|-----------|-------------|
+| Observer | `governance/intake.mjs` | Write: intents table. Read: none. |
+| Governor | `governance/policy.mjs`, `governance/config.mjs` | Read: intents, constitution, policy, roles. Write: governance decision on intent. |
+| Executor | `execution/gmail-executor.mjs`, `routes/index.mjs` (execute routes) | Read: intents (authorized only), execution tokens. Write: execution result, receipt, ledger entry. |
+
+### 3.2 Handoff Contracts
+
+Every transition between powers produces a cryptographic hash that is recorded in the ledger. The hash chain proves the sequence of events is tamper-evident.
+
+```
+Observer                    Governor                    Executor
+   │                           │                           │
+   ├── IntentEnvelope ────────►│                           │
+   │   [intent_hash]           │                           │
+   │                           ├── GovernanceDecision ────►│
+   │                           │   [governance_hash]       │
+   │                           │                           ├── ExecutionResult
+   │                           │                           │   [execution_hash]
+   │                           │                           │
+   │                           │                           ├── Receipt
+   │                           │                           │   [receipt_hash]
+   │                           │                           │
+   ▼                           ▼                           ▼
+                        LEDGER (append-only, hash-chained)
+```
+
+### 3.3 Hash Chain Integrity
+
+Each ledger entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `entry_id` | Auto-incrementing integer |
+| `intent_id` | UUID of the associated intent |
+| `action` | Pipeline stage (submit, govern, authorize, execute, receipt, kill) |
+| `hash` | SHA-256 of the entry payload |
+| `prev_hash` | SHA-256 hash of the previous entry (genesis = "0000...0000") |
+| `timestamp` | ISO-8601 timestamp |
+| `data` | JSONB payload specific to the action |
+
+**Verification:** `GET /verify` walks the entire chain and confirms every entry's `prev_hash` matches the preceding entry's `hash`. If any link is broken, the chain is invalid and the system reports the break point.
+
+---
+
+## 4. Fail-Closed Invariants
+
+The system defaults to denial. These invariants are structural — they cannot be overridden by configuration, policy, or user action.
+
+| Invariant | Enforcement |
+|-----------|-------------|
+| No execution without authorization | Executor checks intent status = `authorized` before dispatching |
+| No authorization without governance | Authorize route checks intent status = `governed` before accepting approval |
+| No governance without observation | Govern route checks intent exists and status = `submitted` |
+| Single-use execution tokens | Token is burned immediately on use; re-use returns 409 |
+| Ed25519 signature required (when mode = required) | Unsigned authorization returns 400 |
+| Human final authority | `REQUIRE_HUMAN` verdict blocks until signed human approval |
+| Kill switch overrides all | `POST /api/kill` burns all tokens and pauses the proxy immediately |
+
+---
+
+## 5. Identity Binding
+
+Every authorization is cryptographically bound to a specific human identity through Ed25519 signatures.
+
+### 5.1 Signer Lifecycle
+
+```
+Generate Keypair → Register Public Key → Sign Authorizations → [Revoke if compromised]
+```
+
+| Stage | Endpoint | What Happens |
+|-------|----------|--------------|
+| Generate | `POST /api/signers/generate-keypair` | Server generates Ed25519 keypair, returns secret key ONCE, stores only public key |
+| Register | `POST /api/signers/register` | Accept externally-generated public key, bind to signer_id |
+| Authorize | `POST /authorize` | Verify signature against registered public key |
+| Revoke | `DELETE /api/signers/:signer_id` | Mark signer as revoked, reject future signatures |
+
+### 5.2 Signature Payload (Canonical JSON)
+
+The signed payload for authorization is a deterministic JSON string:
+
+```json
+{
+  "intent_id": "<uuid>",
+  "action": "<action_type>",
+  "decision": "approved",
+  "signer_id": "<signer_id>",
+  "timestamp": "<ISO-8601>"
+}
+```
+
+Keys are sorted alphabetically. The signature is computed over the UTF-8 bytes of this string using Ed25519.
+
+### 5.3 Receipt Identity Binding
+
+Every receipt includes an `identity_binding` block:
+
+```json
+{
+  "identity_binding": {
+    "signer_id": "brian-sovereign",
+    "public_key": "721b260779...",
+    "signature_payload_hash": "a3f8c1...",
+    "verification_method": "Ed25519"
+  }
+}
+```
+
+This proves which human authorized the action, with what key, and that the signature was verified at execution time.
+
+---
+
+## 6. Kill Switch
+
+The kill switch is the architectural override. It exists outside the normal pipeline and can halt all activity immediately.
+
+**Endpoint:** `POST /api/kill`
+**Auth:** JWT + Ed25519 signature (dual-factor)
+**Latency requirement:** < 1 second
+
+**Actions on activation:**
+1. Burn ALL active execution tokens for the user
+2. Set proxy user status to `PAUSED`
+3. Log immutable `KILL_PROXY` receipt in ledger with full hash chain
+4. Return confirmation with receipt ID
+
+**Signature payload:**
+```json
+{
+  "action": "KILL_PROXY",
+  "signer_id": "<signer_id>",
+  "user_id": "<user_id>",
+  "timestamp": "<ISO-8601>"
+}
+```
+
+The kill switch cannot be disabled by policy, configuration, or any agent. It is always reachable from any authenticated context.
+
+---
+
+## 7. Separation Matrix
+
+This matrix defines which power can access which system resource. Any violation is a structural breach.
+
+| Resource | Observer | Governor | Executor |
+|----------|----------|----------|----------|
+| Raw intent data | Read | — | — |
+| Normalized intent | Write | Read | Read (authorized only) |
+| Constitution | — | Read | — |
+| Policy | — | Read | — |
+| Role definitions | — | Read | — |
+| Governance decisions | — | Write | Read |
+| Execution tokens | — | — | Read/Burn |
+| External API keys | — | — | Read |
+| OAuth tokens | — | — | Read |
+| Connectors (Gmail, Twilio, etc.) | — | — | Execute |
+| Ledger | Append | Append | Append |
+| Receipts | — | — | Generate |
+| Kill switch | — | — | Execute |
+| Signer registry | — | — | Read (verify) |
+
+---
+
+## 8. Compliance Verification
+
+To verify the Three-Power Separation is intact:
+
+1. **Code audit:** Confirm no module in `governance/` imports from `execution/`. Confirm no module in `execution/` imports from `governance/policy.mjs` or `governance/config.mjs`.
+2. **Runtime check:** `GET /health` reports all three powers as loaded and isolated.
+3. **Ledger check:** `GET /verify` confirms the hash chain is unbroken, proving every transition was recorded.
+4. **Penetration test:** Submit an intent and attempt to execute it without governance. The system must return 409 (wrong status).
+5. **Kill switch test:** Activate kill switch and verify all tokens are burned and proxy is paused within 1 second.
+
+---
+
+## 9. Future Extensions
+
+| Extension | Power Affected | Description |
+|-----------|---------------|-------------|
+| Multi-agent governance | Governor | Multiple agents vote on high-risk intents |
+| Automated escalation | Governor | Time-based escalation if human doesn't respond |
+| Connector plugins | Executor | Add new execution targets without modifying governance |
+| Ingestion adapters | Observer | Add new intent sources (voice, webhook, IoT) |
+| Cross-chain verification | All | External auditor verifies ledger independently |
+
+---
+
+## 10. References
+
+- `spec/core-spec-v1.json` — Core protocol specification
+- `spec/Receipt_Specification_v2.json` — Receipt format specification
+- `spec/INTAKE_SPEC.md` — Intake schema specification
+- `spec/policy-v1.0.json` — Policy schema
+- `docs/RIO_White_Paper_Formal.md` — Formal white paper
+- `gateway/config/rio/RIO_CONSTITUTION.json` — Active constitution
+- `gateway/config/rio/RIO_POLICY.json` — Active governance policy (v1.1)


### PR DESCRIPTION
## Documentation & Specification Updates

### New Specifications
- **spec/THREE_POWER_SEPARATION.md** — Authoritative spec (RIO-SPEC-TPS-001) defining Observer, Governor, and Executor boundaries with API contracts, permission matrices, cross-boundary violation detection, and enforcement mechanisms
- **spec/MANTIS_COMPONENT.md** — Mantis (Observer) component definition with capabilities, constraints, interface contracts, ingestion source mapping, and implementation file references
- **spec/Receipt_Specification_v2.1.json** — Non-breaking schema additions:
  - `ingestion` object on ActionRequest for source provenance tracking
  - `identity_binding` object on Receipt for Ed25519 signer proof
  - `receipt_type` enum: governed_action, kill_switch, onboard, system
  - Canonical ingestion source registry (api, email, sms, webhook, frontend, service_bus, onboard, kill_switch, internal)

### New Documentation
- **docs/API_CATALOG_v2.7.md** — Complete 43-endpoint catalog covering core pipeline, Public API v1, signer management, key backup, device sync, and proxy onboarding (v2.7.0). Includes auth requirements, request/response examples, error codes, rate limits
- **docs/ARCHITECTURE_v2.7.md** — System architecture document covering pipeline stages, Three-Power Separation, security layers, data architecture, module map, deployment topology, version history, and team responsibilities

### Conflict Safety
- Documentation and spec files only — no code changes
- No overlap with PR #78 (policy config) or PR #80 (proxy onboarding)
- No overlap with Manny's Azure pipeline or Jordan's frontend work

### Files Changed
```
spec/THREE_POWER_SEPARATION.md     (new)
spec/MANTIS_COMPONENT.md           (new)
spec/Receipt_Specification_v2.1.json (new)
docs/API_CATALOG_v2.7.md           (new)
docs/ARCHITECTURE_v2.7.md          (new)
```