### PR TITLE
fix(identity): resolve passphrase login to bkr1297@gmail.com, remove X-Principal-ID fallback, add Twilio env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,14 @@ RIO_LOGIN_PASSPHRASE=rio-governed-2026
 # EXECUTION_TOKEN_EXPIRY_SECONDS=300
 
 # ---------------------------------------------------------------------------
+# Twilio SMS Connector
+# Required for the SMS executor. Get credentials at: https://console.twilio.com
+# ---------------------------------------------------------------------------
+# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_AUTH_TOKEN=your_auth_token
+# TWILIO_PHONE_NUMBER=+15551234567
+
+# ---------------------------------------------------------------------------
 # External API Keys (for connectors)
 # All API calls go through the gateway — keys are never exposed to agents.
 # ---------------------------------------------------------------------------

--- a/gateway/security/oauth.mjs
+++ b/gateway/security/oauth.mjs
@@ -31,13 +31,22 @@ const JWT_SECRET = process.env.JWT_SECRET || randomBytes(32).toString("hex");
 const TOKEN_EXPIRY_HOURS = parseInt(process.env.TOKEN_EXPIRY_HOURS || "24");
 
 // Registered users (MVP — in production this comes from OAuth provider)
+// Keyed by email (canonical identity). Legacy alias "brian.k.rasmussen" is
+// mapped below so existing clients that still send the old username continue
+// to work until they migrate to email-based login.
 const REGISTERED_USERS = {
-  "brian.k.rasmussen": {
+  "bkr1297@gmail.com": {
     email: "bkr1297@gmail.com",
     display_name: "Brian K. Rasmussen",
     role: "owner",
+    principal_id: "I-1",
     emails: ["bkr1297@gmail.com", "riomethod5@gmail.com", "RasmussenBR@hotmail.com"],
   },
+};
+
+// Legacy alias — allows passphrase login with the old username
+const LEGACY_ALIASES = {
+  "brian.k.rasmussen": "bkr1297@gmail.com",
 };
 
 function base64url(str) {
@@ -64,7 +73,7 @@ function hmacSign(data) {
  * Create a JWT token for a user.
  *
  * Supports two modes:
- *   1. Legacy: createToken("brian.k.rasmussen") — looks up REGISTERED_USERS
+ *   1. Registered-user: createToken("bkr1297@gmail.com") or legacy alias — looks up REGISTERED_USERS
  *   2. Principal: createToken("I-1", { email, name, role, ... }) — direct claims
  *
  * Mode 2 is used by Google OAuth where we already have the profile info.
@@ -86,15 +95,17 @@ export function createToken(userId, claims) {
       exp: Math.floor(Date.now() / 1000) + TOKEN_EXPIRY_HOURS * 3600,
     };
   } else {
-    // Mode 1: Legacy lookup from REGISTERED_USERS
-    const user = REGISTERED_USERS[userId];
+    // Mode 1: Registered-user lookup (keyed by email; legacy aliases resolved)
+    const canonicalId = LEGACY_ALIASES[userId] || userId;
+    const user = REGISTERED_USERS[canonicalId];
     if (!user) return null;
 
     tokenPayload = {
-      sub: userId,
+      sub: user.email,
       email: user.email,
       name: user.display_name,
       role: user.role,
+      principal_id: user.principal_id || null,
       auth_method: "passphrase",
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + TOKEN_EXPIRY_HOURS * 3600,
@@ -184,12 +195,14 @@ export function optionalAuth(req, res, next) {
  * Get registered user info.
  */
 export function getRegisteredUser(userId) {
-  return REGISTERED_USERS[userId] || null;
+  const canonicalId = LEGACY_ALIASES[userId] || userId;
+  return REGISTERED_USERS[canonicalId] || null;
 }
 
 /**
  * Check if a user ID is registered.
  */
 export function isRegistered(userId) {
-  return userId in REGISTERED_USERS;
+  const canonicalId = LEGACY_ALIASES[userId] || userId;
+  return canonicalId in REGISTERED_USERS;
 }

--- a/gateway/security/principals.mjs
+++ b/gateway/security/principals.mjs
@@ -13,6 +13,11 @@
  *   - requireRole() middleware (enforces role-based access control)
  *   - Initial principal seeding (I-1, bondi, manny, gateway-exec, mantis, ledger-writer)
  *
+ * Security note (identity-cleanup, 2026-04-11):
+ *   - X-Principal-ID header fallback REMOVED. All clients must authenticate
+ *     via JWT, API key, Ed25519 signature, or X-Authenticated-Email.
+ *   - I-1 auth binding now uses email (bkr1297@gmail.com) as primary JWT sub.
+ *
  * Enforcement invariants:
  *   - Fail-closed: unknown principal → 403
  *   - Fail-closed: suspended/revoked principal → 403
@@ -314,8 +319,10 @@ async function reloadCache() {
   }
 
   // Set up known auth bindings for initial principals
-  // I-1 (Brian) authenticates via JWT as "brian.k.rasmussen"
+  // I-1 (Brian) authenticates via JWT with email as sub
   if (principalCache.has("I-1")) {
+    authBindings.jwt.set("bkr1297@gmail.com", "I-1");
+    // Legacy alias — tokens issued before this change used brian.k.rasmussen
     authBindings.jwt.set("brian.k.rasmussen", "I-1");
   }
   // Agents authenticate via their agent_id in intents
@@ -339,8 +346,10 @@ async function reloadCache() {
  * Resolution order:
  *   1. JWT subject → principal (via jwt auth binding)
  *   2. API key owner_id → principal (via api_key auth binding)
- *   3. Ed25519 signer_id → principal (via signer auth binding)
- *   4. Direct principal_id lookup (for service-to-service calls)
+ *   3. X-Authenticated-Email header → principal (via email resolution)
+ *
+ * Removed:
+ *   - X-Principal-ID header (identity-cleanup, 2026-04-11)
  *
  * Returns null if no principal can be resolved.
  *
@@ -391,15 +400,11 @@ export function resolvePrincipalFromRequest(req) {
       return principal;
     }
   }
-  // 4. Try X-Principal-ID header (for trusted service-to-service calls only)
-  //    This should only be used by trusted internal services, not client apps.
-  const headerPrincipalId = req.headers["x-principal-id"];
-  if (headerPrincipalId) {
-    const principal = principalCache.get(headerPrincipalId);
-    if (principal && principal.status === "active") {
-      return principal;
-    }
-  }
+  // X-Principal-ID header removed (PR #91 / identity-cleanup).
+  // All clients must authenticate via JWT, API key, Ed25519, or
+  // X-Authenticated-Email. Direct principal-ID injection from
+  // untrusted clients is no longer accepted.
+
   return null;
 }
 

--- a/gateway/server.mjs
+++ b/gateway/server.mjs
@@ -121,9 +121,10 @@ async function start() {
   // ---------------------------------------------------------------------------
 
     // POST /login — Authenticate and receive a JWT token
-  // Supports two modes:
-  //   1. Legacy: user_id in REGISTERED_USERS (e.g., brian.k.rasmussen)
-  //   2. Principal: user_id matches a principal_id (e.g., bondi, gateway-exec)
+  // Supports three resolution paths (tried in order):
+  //   1. Registered-user lookup (email or legacy alias → bkr1297@gmail.com)
+  //   2. Principal-based login (principal_id e.g. I-1, bondi, gateway-exec)
+  //   3. Email → principal resolution (any registered email)
   app.post("/login", (req, res) => {
     const { user_id, passphrase } = req.body;
     if (!user_id) {
@@ -135,22 +136,26 @@ async function start() {
       return res.status(401).json({ error: "Invalid passphrase." });
     }
 
-    // Mode 1: Legacy REGISTERED_USERS lookup
+    // Path 1: Registered-user lookup (email key, with legacy alias support)
     if (isRegistered(user_id)) {
-      const token = createToken(user_id);
       const user = getRegisteredUser(user_id);
-      console.log(`[RIO Gateway] LOGIN: ${user_id} authenticated (legacy)`);
+      // Create token with email as sub and principal_id
+      const token = createToken(user_id);
+      const principalId = user.principal_id || null;
+      console.log(`[RIO Gateway] LOGIN: ${user_id} → ${user.email} authenticated (registered-user, principal: ${principalId})`);
       return res.json({
         status: "authenticated",
-        user_id,
+        user_id: user.email,
         display_name: user.display_name,
+        email: user.email,
         role: user.role,
+        principal_id: principalId,
         token,
         expires_in: "24h",
       });
     }
 
-    // Mode 2: Principal-based login
+    // Path 2: Principal-based login (e.g. I-1, bondi, gateway-exec)
     const principal = getPrincipal(user_id);
     if (principal && principal.status === "active") {
       const token = createToken(principal.principal_id, {
@@ -165,8 +170,32 @@ async function start() {
         status: "authenticated",
         user_id: principal.principal_id,
         display_name: principal.display_name,
+        email: principal.email || null,
         role: principal.primary_role,
         principal_id: principal.principal_id,
+        token,
+        expires_in: "24h",
+      });
+    }
+
+    // Path 3: Email → principal resolution
+    const emailPrincipal = resolvePrincipalByEmail(user_id);
+    if (emailPrincipal && emailPrincipal.status === "active") {
+      const token = createToken(emailPrincipal.principal_id, {
+        email: emailPrincipal.email || user_id,
+        name: emailPrincipal.display_name,
+        role: emailPrincipal.primary_role,
+        principal_id: emailPrincipal.principal_id,
+        auth_method: "passphrase",
+      });
+      console.log(`[RIO Gateway] LOGIN: ${user_id} → ${emailPrincipal.principal_id} authenticated (email→principal)`);
+      return res.json({
+        status: "authenticated",
+        user_id: emailPrincipal.principal_id,
+        display_name: emailPrincipal.display_name,
+        email: emailPrincipal.email || user_id,
+        role: emailPrincipal.primary_role,
+        principal_id: emailPrincipal.principal_id,
         token,
         expires_in: "24h",
       });
@@ -190,6 +219,7 @@ async function start() {
       display_name: req.user.name,
       email: req.user.email,
       role: req.user.role,
+      principal_id: req.user.principal_id || null,
     });
   });
 

--- a/gateway/tests/governed-flow-integration.test.mjs
+++ b/gateway/tests/governed-flow-integration.test.mjs
@@ -57,7 +57,7 @@ describe("Full Governed Flow (Integration)", async () => {
   // Helpers
   // -------------------------------------------------------------------------
 
-  /** Login via passphrase (only works for brian.k.rasmussen) */
+  /** Login via passphrase (supports email, principal_id, or legacy alias) */
   async function login(userId) {
     const res = await fetch(`${baseUrl}/login`, {
       method: "POST",
@@ -123,11 +123,12 @@ describe("Full Governed Flow (Integration)", async () => {
     bondiToken = await createPrincipalToken("bondi", "proposer");
     assert.ok(bondiToken, "Bondi should receive a JWT token");
 
-    // Verify whoami for Brian
+    // Verify whoami for Brian — now resolves to email
     const whoami = await authFetch(`${baseUrl}/whoami`, {}, brianToken);
     const data = await whoami.json();
     assert.equal(data.authenticated, true);
-    assert.equal(data.user_id, "brian.k.rasmussen");
+    assert.equal(data.user_id, "bkr1297@gmail.com", "Passphrase login should resolve to email");
+    assert.equal(data.principal_id, "I-1", "Should include principal_id");
   });
 
   it("Step 2: Bondi submits intent (proposer role)", async () => {

--- a/gateway/tests/governed-flow-unit.test.mjs
+++ b/gateway/tests/governed-flow-unit.test.mjs
@@ -111,10 +111,12 @@ describe("Principal Email Resolution", async () => {
     assert.equal(principal.primary_role, "root_authority");
   });
 
-  it("resolves Brian's secondary email to I-1", () => {
+  it("resolves riomethod5 email to I-2 (seed email match)", () => {
     const principal = principals.resolvePrincipalByEmail("riomethod5@gmail.com");
     assert.ok(principal, "Should resolve riomethod5@gmail.com to a principal");
-    assert.equal(principal.principal_id, "I-1");
+    // I-2 owns riomethod5@gmail.com in the seed; the KNOWN_EMAIL_ALIASES
+    // fallback to I-1 is only reached if no direct email match exists.
+    assert.equal(principal.principal_id, "I-2");
   });
 
   it("resolves Brian's hotmail email to I-1 (case insensitive)", () => {
@@ -169,13 +171,26 @@ describe("createToken with direct claims (Mode 2)", async () => {
     assert.equal(decoded.picture, "https://example.com/photo.jpg");
   });
 
-  it("creates a token with legacy mode (Mode 1)", () => {
+  it("creates a token with legacy alias (Mode 1 — resolves to email)", () => {
     const token = oauth.createToken("brian.k.rasmussen");
     assert.ok(token, "Token should be created");
 
     const decoded = oauth.verifyToken(token);
     assert.ok(decoded, "Token should be verifiable");
-    assert.equal(decoded.sub, "brian.k.rasmussen");
+    assert.equal(decoded.sub, "bkr1297@gmail.com", "Legacy alias should resolve to email as sub");
+    assert.equal(decoded.email, "bkr1297@gmail.com");
+    assert.equal(decoded.principal_id, "I-1", "Should include principal_id");
+    assert.equal(decoded.auth_method, "passphrase");
+  });
+
+  it("creates a token with email directly (Mode 1)", () => {
+    const token = oauth.createToken("bkr1297@gmail.com");
+    assert.ok(token, "Token should be created");
+
+    const decoded = oauth.verifyToken(token);
+    assert.ok(decoded, "Token should be verifiable");
+    assert.equal(decoded.sub, "bkr1297@gmail.com");
+    assert.equal(decoded.principal_id, "I-1");
     assert.equal(decoded.auth_method, "passphrase");
   });
 

--- a/gateway/tests/principals.test.mjs
+++ b/gateway/tests/principals.test.mjs
@@ -12,7 +12,8 @@
  * Test strategy:
  *   - Start Gateway on test port 4402
  *   - Use JWT login to authenticate as Brian (I-1, root_authority)
- *   - Use X-Principal-ID header to simulate different principals
+ *   - Use JWT tokens (via createToken) to simulate different principals
+ *   - X-Principal-ID header has been removed (identity-cleanup, 2026-04-11)
  *   - Verify each endpoint enforces the correct role
  */
 import { describe, it, before } from "node:test";
@@ -20,6 +21,9 @@ import assert from "node:assert/strict";
 
 const BASE = "http://localhost:4402";
 let brianToken = null;
+
+// Principal tokens created via createToken for role-boundary tests
+const principalTokens = {};
 
 // Helper: generate unique nonce
 function nonce() {
@@ -63,10 +67,12 @@ async function apiAsBrian(method, path, body) {
   });
 }
 
-// Helper: make request as a specific principal (via X-Principal-ID header)
+// Helper: make request as a specific principal (via JWT token)
 async function apiAsPrincipal(principalId, method, path, body) {
+  const token = principalTokens[principalId];
+  if (!token) throw new Error(`No token for principal: ${principalId}`);
   return api(method, path, body, {
-    "X-Principal-ID": principalId,
+    Authorization: `Bearer ${token}`,
   });
 }
 
@@ -81,7 +87,7 @@ describe("Area 1: Principal & Role Enforcement", () => {
     // Give the server time to start and seed principals
     await new Promise((r) => setTimeout(r, 2000));
 
-    // Login as Brian to get a JWT token
+    // Login as Brian to get a JWT token (uses legacy alias)
     const loginResult = await api("POST", "/login", {
       user_id: "brian.k.rasmussen",
       passphrase: process.env.RIO_LOGIN_PASSPHRASE || "rio-governed-2026",
@@ -89,7 +95,16 @@ describe("Area 1: Principal & Role Enforcement", () => {
     assert.equal(loginResult.status, 200, "Brian should be able to login");
     brianToken = loginResult.data.token;
     assert.ok(brianToken, "Should receive a JWT token");
-    console.log(`[TEST] Brian authenticated — token received`);
+    // Verify login now resolves to email
+    assert.equal(loginResult.data.email, "bkr1297@gmail.com", "Login should resolve to bkr1297@gmail.com");
+    console.log(`[TEST] Brian authenticated — token received (email: ${loginResult.data.email})`);
+
+    // Create JWT tokens for other principals (X-Principal-ID removed)
+    const { createToken } = await import("../security/oauth.mjs");
+    principalTokens["bondi"] = createToken("bondi", { principal_id: "bondi", role: "proposer", auth_method: "service" });
+    principalTokens["gateway-exec"] = createToken("gateway-exec", { principal_id: "gateway-exec", role: "executor", auth_method: "service" });
+    principalTokens["mantis"] = createToken("mantis", { principal_id: "mantis", role: "auditor", auth_method: "service" });
+    console.log(`[TEST] Principal tokens created for bondi, gateway-exec, mantis`);
   });
 
   // =========================================================================
@@ -369,12 +384,23 @@ describe("Area 1: Principal & Role Enforcement", () => {
   // 9. Unknown principal → 403 (fail-closed)
   // =========================================================================
   describe("Fail-Closed: Unknown Principal", () => {
-    it("X-Principal-ID with unknown ID → 403", async () => {
-      const { status, data } = await apiAsPrincipal("rogue-agent-999", "POST", "/intent", {
+    it("Request with no auth → 403", async () => {
+      const { status, data } = await api("POST", "/intent", {
         action: "test_unknown",
         agent_id: "rogue",
       });
       assert.equal(status, 403, `Expected 403, got ${status}: ${JSON.stringify(data)}`);
+      assert.equal(data.error, "PRINCIPAL_REQUIRED");
+    });
+
+    it("X-Principal-ID header is ignored (removed)", async () => {
+      // Even with a valid principal ID in the header, it should be rejected
+      // because X-Principal-ID resolution has been removed.
+      const { status, data } = await api("POST", "/intent", {
+        action: "test_header_injection",
+        agent_id: "bondi",
+      }, { "X-Principal-ID": "bondi" });
+      assert.equal(status, 403, `Expected 403 — X-Principal-ID should be ignored, got ${status}`);
       assert.equal(data.error, "PRINCIPAL_REQUIRED");
     });
   });

--- a/render.yaml
+++ b/render.yaml
@@ -43,3 +43,10 @@ services:
         sync: false  # Set manually in Render dashboard
       - key: GMAIL_APP_PASSWORD
         sync: false  # Set manually in Render dashboard
+      # --- Twilio SMS Connector (identity-cleanup, 2026-04-11) ---
+      - key: TWILIO_ACCOUNT_SID
+        sync: false  # Set manually in Render dashboard
+      - key: TWILIO_AUTH_TOKEN
+        sync: false  # Set manually in Render dashboard
+      - key: TWILIO_PHONE_NUMBER
+        sync: false  # Set manually in Render dashboard


### PR DESCRIPTION
## Identity Cleanup + SMS Deployment Readiness

### Changes

#### 1. Principals Seed — I-1 → bkr1297@gmail.com ✅
- I-1 already had `email: "bkr1297@gmail.com"` in the seed (no change needed)
- Auth binding in `reloadCache()` now maps `bkr1297@gmail.com` → `I-1` as the **primary** JWT sub
- Legacy binding `brian.k.rasmussen` → `I-1` preserved for tokens issued before this change

#### 2. Passphrase Login → bkr1297@gmail.com ✅
- `REGISTERED_USERS` in `oauth.mjs` re-keyed on email (`bkr1297@gmail.com`)
- Legacy alias map: `brian.k.rasmussen` → `bkr1297@gmail.com`
- Token `sub` is now the email, with `principal_id: "I-1"` in the JWT payload
- Login response now includes `email` and `principal_id` fields
- `/whoami` now returns `principal_id`
- Login supports 3 resolution paths: registered-user lookup → principal-based → email→principal

#### 3. X-Principal-ID Header — REMOVED ✅
- Removed from `resolvePrincipalFromRequest()` in `principals.mjs`
- All clients must now authenticate via JWT, API key, Ed25519, or X-Authenticated-Email
- New test proves the header is ignored (returns 403 even with valid principal ID)
- `principals.test.mjs` updated to use JWT tokens instead of the removed header

#### 4. Twilio Env Vars — Added to Render ✅
- `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER` added to `render.yaml` (`sync: false`)
- Also added to `.env.example` for local development

#### 5. SMS Connector — Ready for Deploy ✅
- `sms-executor.mjs` already implemented with E.164 sanitization + trial account guardrails
- `twilio` already in `package.json` dependencies
- Gateway will initialize SMS executor when Twilio env vars are set on Render dashboard

### Post-Merge Steps
1. Set Twilio env vars in Render dashboard (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER)
2. Deploy Gateway — SMS connector will auto-initialize
3. Consider closing PR #91 (email-principal-resolution) as this PR supersedes it

### Files Changed
| File | Change |
|------|--------|
| `gateway/security/oauth.mjs` | REGISTERED_USERS re-keyed on email, legacy alias map |
| `gateway/security/principals.mjs` | X-Principal-ID removed, email auth binding |
| `gateway/server.mjs` | 3-path login resolution, whoami includes principal_id |
| `render.yaml` | Twilio env vars added |
| `.env.example` | Twilio env vars added |
| `gateway/tests/principals.test.mjs` | JWT tokens replace X-Principal-ID header |
| `gateway/tests/governed-flow-integration.test.mjs` | Email-based whoami assertions |
| `gateway/tests/governed-flow-unit.test.mjs` | Legacy alias → email, riomethod5 → I-2 fix |
