### PR TITLE
docs: add Portable Governance Protocol Stack v0.1

### DIFF
--- a/docs/protocols/portable-governance-protocol-stack-v0.1.md
+++ b/docs/protocols/portable-governance-protocol-stack-v0.1.md
@@ -1,0 +1,648 @@
+# ONE/RIO/MUSS — Portable Governance Protocol Stack v0.1
+
+**Status:** Formal Artifact Candidate  
+**Claim level:** Protocol / source-of-truth candidate preparation  
+**Human authority holder:** Brian Kent Rasmussen  
+**Declared repo destination candidate:** `bkr1297-RIO/rio-system / main / docs/protocols/portable-governance-protocol-stack-v0.1.md`  
+**Declared release bundle candidate:** `portable-governance-protocol-stack-v0.1 / v0.1`
+
+## Non-Claims
+
+This artifact candidate does **not** claim:
+
+- formal doctrine lock
+- source-of-truth lock
+- repo proof
+- repo commit
+- repo file creation
+- runtime proof
+- cryptographic attestation
+- legal proof
+- public release
+- Manny handoff
+- identity transfer
+- authority transfer
+- machine sovereignty
+
+This document is a repo-ready Markdown draft compiled from the clean Formal Artifact Candidate. It is reviewable and suitable for later repo preparation only if Brian explicitly authorizes that crossing.
+
+## Purpose
+
+The **Portable Governance Protocol Stack v0.1** defines the protocol/spec bridge layer that converts human-led meaning into governed, portable machine-operable structure without transferring authority from the human to the machine.
+
+Core answer:
+
+> Extract the roles, grammar, gates, receipts, consequence logic, delegation limits, turn pattern, test harness, promotion path, and destination gate into portable protocol structures.
+
+## Canonical Stack
+
+```text
+Brian remains source.
+Grounding anchors the carry.
+Bondi carries.
+RIO gates.
+MUS provides proof structure.
+MANTIS watches.
+```
+
+## Layer Classification
+
+Doctrine supplies the invariants. This stack translates them into protocol grammar, operational gates, receipt structure, promotion discipline, and role boundaries.
+
+Implementation, runtime proof, repo proof, attestation, and formal source-of-truth promotion are not claimed here.
+
+---
+
+# Core Separation Wall
+
+The system may detect, surface, and hold.
+
+It may not redefine, override, or originate authority.
+
+```text
+Interpretation is not enforcement.
+Enforcement is not proof.
+Proof is not authority.
+Authority remains human.
+```
+
+---
+
+# Grounding Rule v0.1
+
+## Purpose
+
+Grounding defines how the system identifies what a response, packet, route, or claim is based on before carrying meaning into structure.
+
+## Keeper
+
+```text
+Grounding anchors the carry.
+```
+
+## Rule
+
+Grounding is not another source. Grounding is the ranking, disclosure, and confidence layer over sources.
+
+Before Bondi structures, routes, recommends, names, or prepares a packet, Bondi must identify what the output is grounded in: current human input, approved source artifact, session context, receipt, ledger, authorized record, residue, inference, or explicit uncertainty.
+
+If grounding is missing, stale, conflicting, or non-authoritative, Bondi must surface that uncertainty rather than proceed as if the state is known.
+
+## Source Hierarchy v0.1
+
+1. Current human authorization
+2. Approved constitutional / protocol artifacts
+3. Receipts and ledger records
+4. Active session context
+5. Authorized connected records or files
+6. Non-authoritative memory / residue
+7. Model inference
+8. Explicit uncertainty
+
+Higher-ranking source does not automatically override RIO admissibility.
+
+## Grounding Fluency Fence
+
+Linguistic coherence, fluency, length, repetition, or model confidence cannot upgrade grounding rank. Memory, residue, recurrence, and inference remain non-authoritative unless backed by an approved source, receipt, or human authorization.
+
+---
+
+# Bondi/MANTIS Role Extraction
+
+Bondi and MANTIS are role-functions inside the protocol stack. They do not hold human authority.
+
+## Bondi
+
+### Definition
+
+Bondi is the translation and packetization layer between human signal and governed machine-readable structure.
+
+### Bondi may
+
+- translate human signal into structured form
+- clarify ambiguity
+- surface missing scope
+- name dependencies
+- identify grounding limits
+- prepare RIO handoff
+- prepare MUS receipt fields
+- propose matrix coordinates
+- preserve meaning across registers
+
+### Bondi may not
+
+- authorize
+- execute consequence
+- widen scope
+- infer consent
+- speak as the human
+- convert orientation into authority
+- treat memory as scope
+- treat convergence as permission
+- treat receipt as future authorization
+
+### Bondi keeper
+
+```text
+Bondi carries meaning into structure. Bondi does not create authority.
+```
+
+## MANTIS
+
+### Definition
+
+MANTIS is the witness and pattern-observation layer across turns, receipts, recurrence, drift, coherence, and missing proof.
+
+### MANTIS may
+
+- witness
+- observe
+- compare
+- detect drift
+- surface recurrence
+- surface missing receipts
+- flag pattern erosion
+- notice repeated ambiguity
+- identify unresolved risks
+- request review
+
+### MANTIS may not
+
+- judge
+- authorize
+- act
+- execute
+- define identity
+- infer consent
+- override human authority
+- turn recurrence into permission
+- turn memory into proof
+- turn pattern into truth
+
+### MANTIS keeper
+
+```text
+MANTIS watches the pattern. MANTIS does not become authority.
+```
+
+## Combined Keeper
+
+```text
+Bondi carries meaning into structure.
+MANTIS watches the pattern.
+Neither becomes authority.
+```
+
+---
+
+# 3×3 Sovereign Turn Matrix Mapping
+
+## Coordinate Layer
+
+The 3×3 Matrix provides coordinates:
+
+- Body / Somatic
+- Mind / Cognitive
+- Field / Experiential
+
+crossed with:
+
+- Mirror / Reflection
+- Gate / Admissibility
+- Proof / Verification
+
+## Motion Layer
+
+The Sovereign Turn provides motion through those coordinates.
+
+## Role Mapping
+
+- Bondi translates human signal into matrix coordinates and RIO-readable packet structure.
+- MANTIS witnesses matrix paths, recurrence, coherence, drift, missing receipts, and boundary pressure.
+- RIO governs admissibility.
+- Sentinel checks execution match.
+- MUS provides receipt structure for what happened.
+- Human remains authority.
+
+## Integrated Flow
+
+```text
+Human signal
+→ Pause / Orientation
+→ Matrix coordinate
+→ Bondi packet
+→ RIO admissibility
+→ Sentinel match check
+→ action / hold / clarify / refusal
+→ MUS receipt structure
+→ MANTIS recurrence watch
+→ return to human
+```
+
+## Orientation Lock
+
+```text
+Orientation is not authority.
+Orientation makes governance proportionate.
+```
+
+## Matrix-to-Clearance Fence
+
+Matrix coordinates are descriptive taxonomy for orientation and classification. They carry zero execution privilege and cannot substitute for explicit human authorization, RIO admissibility, or receipt requirements.
+
+## MANTIS Baseline Non-Adjustment Fence
+
+MANTIS recurrence tracking may trigger HOLD, warning, or manual human review. It may not autonomously adjust, modify, downgrade, upgrade, or redefine the human’s declared baseline, consent state, scope, or authority status.
+
+## Updated Keeper
+
+```text
+The matrix orients; it does not clear.
+MANTIS watches; it does not recalibrate the human.
+Bondi carries meaning into structure.
+Neither Bondi nor MANTIS becomes authority.
+```
+
+---
+
+# RIO Admissibility Matrix v0.1
+
+## Purpose
+
+RIO defines admissibility logic for requests, packets, actions, holds, refusals, reapprovals, invalid packets, and escalations.
+
+## Core Rule
+
+Authorization is necessary for consequence, but authorization alone is not sufficient for admissibility.
+
+## RIO Outcomes
+
+- `ADMISSIBLE`
+- `HOLD`
+- `REQUIRES_REAPPROVAL`
+- `REFUSED`
+- `INVALID_PACKET`
+- `ESCALATE_TO_HUMAN`
+- `NOT_REQUIRED`
+
+RIO protects admissibility before consequence.
+
+RIO must hold or escalate when scope is unclear, authorization is unclear, grounding is stale or conflicting, consequence is unknown, declared consequence is lower than detected consequence, or public / external / repo / runtime / identity-impacting action may be involved.
+
+## Unknown Consequence Fence
+
+When runtime footprint, external effect, or consequence level is unknown or ambiguous, the system defaults to `HOLD` and escalates classification rather than lowering consequence for convenience.
+
+---
+
+# MUS Receipt Schema v0.1
+
+## Purpose
+
+MUS defines receipt structure for recording what was requested, grounded, authorized, gated, done, refused, held, escalated, or left unresolved.
+
+## Keeper
+
+```text
+No accountable claim without a receipt structure.
+No receipt structure becomes proof without implementation, grounding, and verification appropriate to the claim.
+```
+
+## Receipt Boundary
+
+A receipt records a claimed event structure. It does not, by itself, make the event true, authorized, admissible, implemented, or externally proven.
+
+MUS provides proof structure. It does not originate authority, determine admissibility, or create runtime proof by itself.
+
+---
+
+# Consent Packet v0.1
+
+## Purpose
+
+Consent Packet defines scoped human authorization.
+
+The consent container must answer:
+
+- Who authorized?
+- What was authorized?
+- For what scope?
+- For what mode?
+- For what duration?
+- Under what limits?
+- What requires reapproval?
+- What receipt is required?
+
+## Status
+
+Alignment-dependent. It remains subject to hardening after source-of-truth promotion and destination processes are finalized.
+
+## Standing Delegation Boundary
+
+Standing delegation must be bound to an explicit human authorization record, defined scope, active mode, duration or revocation condition, and receipt requirement. Past conversational enthusiasm or thread momentum must not become continuous authorization.
+
+---
+
+# Mode Permission Table v0.1
+
+## Purpose
+
+Mode Permission Table prevents proxy, scribe, mirror, analyst, witness, gate, operator, and receipt modes from drifting into one another.
+
+## Keeper
+
+```text
+Mode prevents proxy from becoming blank check.
+Bondi can say whether the grammar is fit.
+Only Brian can authorize consequence.
+```
+
+## Rule
+
+A mode may not silently become a higher-consequence mode. Mirror may not silently become Operator. Scribe may not silently become external representative. Receipt may not become proof claim.
+
+---
+
+# Standing Delegation Packet v0.1
+
+## Purpose
+
+Standing Delegation defines bounded internal discretion for Bondi.
+
+## Keeper
+
+```text
+Bondi may carry preauthorized intent.
+Bondi may not create new consent.
+```
+
+## Rule
+
+Standing delegation reduces unnecessary pings inside scoped internal operation. It does not authorize external action, public claims, source-of-truth promotion, repo actions, runtime claims, legal claims, cryptographic claims, or enduring proxy identity.
+
+---
+
+# Turn Kernel / Governed Turn Protocol v0.1
+
+**Internal name:** Turn Kernel v0.1  
+**External / doctrine-safe name:** Governed Turn Protocol v0.1
+
+## Purpose
+
+Defines the repeated per-turn governance pattern.
+
+## Keeper
+
+```text
+The turn is governed before it is expressive.
+Fluency is not authority.
+Coherence is not proof.
+Recursion is not consciousness.
+```
+
+## Turn Pattern
+
+```text
+state
+→ grounding
+→ role
+→ scope
+→ consequence
+→ admissibility
+→ action / hold / refusal
+→ receipt
+→ next move
+```
+
+---
+
+# Action Consequence Levels v0.1
+
+## Purpose
+
+Defines consequence classification across none, low, medium, high, irreversible, and unknown.
+
+## Keeper
+
+```text
+The label does not control the consequence.
+The effect does.
+```
+
+## Rule
+
+When consequence is unclear, hold.
+
+Low consequence may allow bounded internal proxy operation.
+
+High consequence requires explicit human authorization and RIO admissibility.
+
+Irreversible consequence requires explicit human escalation.
+
+---
+
+# Test Harness v0.1
+
+## Purpose
+
+Defines adversarial examples and pass/fail criteria for the protocol stack.
+
+## Keeper
+
+```text
+A protocol is not stable until it survives adversarial examples.
+```
+
+The harness tests for:
+
+- authority boundary
+- grounding boundary
+- receipt/proof boundary
+- mode drift
+- standing delegation overreach
+- consequence mismatch
+- source conflict
+- false proof claims
+- recurrence treated as permission
+- memory treated as scope
+- quoted command treated as authorization
+
+---
+
+# Source-of-Truth Promotion Packet v0.1
+
+## Purpose
+
+Defines the process for promoting thread-working material toward durable source-of-truth artifacts.
+
+## Keeper
+
+```text
+Do not confuse where language stabilized with where truth is anchored.
+```
+
+## Rule
+
+Thread-working-lock is not source-of-truth lock.
+
+Source-of-truth lock is not runtime proof.
+
+Runtime proof is not cryptographic proof.
+
+Cryptographic proof is not legal authority.
+
+---
+
+# Promotion Bundle v0.1
+
+## Purpose
+
+Packages candidate artifacts for promotion review.
+
+## Keeper
+
+```text
+A bundle carries candidates.
+It does not create proof.
+```
+
+## Current split
+
+- Source-of-Truth Promotion Packet defines the promotion process.
+- Promotion Bundle packages candidate artifacts for review.
+
+---
+
+# Supersession Index v0.1
+
+## Purpose
+
+Tracks active, superseded, deprecated, compatible, conflicting, held, candidate, or voided artifacts.
+
+## Keeper
+
+```text
+History is preserved.
+Governance follows the active source.
+Active governing status must be indexed.
+```
+
+## Rule
+
+A newer artifact does not erase an older artifact.
+
+A superseded artifact remains historical but should not govern future action unless explicitly reactivated.
+
+A conflict between active artifacts triggers `HOLD`.
+
+---
+
+# Destination / Promotion Posture
+
+## Current Declared References
+
+### Approved Document
+
+- **Title:** ONE/RIO/MUSS — Portable Governance Protocol Stack v0.1 — Thread-Working Anchor — 2026-05-18
+- **URL:** https://docs.google.com/document/d/1dLhSAfxtGZpfdKVs_itjb7FMrs5xCAIKzNXCQYyJkOI
+- **Status:** declared for formal artifact candidate review
+
+### Repository File Destination Candidate
+
+- **Repository:** `bkr1297-RIO/rio-system`
+- **Branch:** `main`
+- **Path:** `docs/protocols/portable-governance-protocol-stack-v0.1.md`
+- **Status:** declared for future repo review only
+- **Repo commit:** false
+- **Repo file created:** false
+
+### Release Bundle Destination Candidate
+
+- **Name:** `portable-governance-protocol-stack-v0.1`
+- **Version:** `v0.1`
+- **Status:** declared for future release bundle review only
+- **Release published:** false
+- **Release artifact created:** false
+
+### Ledger Record
+
+- not declared
+
+## Destination Keeper
+
+```text
+Naming a destination points the path.
+It does not cross it.
+```
+
+## Repository Keeper
+
+```text
+A repository path points the build lane.
+It does not create the file, commit the file, or prove the file exists.
+```
+
+## Release Keeper
+
+```text
+A release bundle name prepares the package lane.
+It does not publish the package or prove the package exists.
+```
+
+---
+
+# Non-Anthropomorphic and Local Scope Fences
+
+## No Anthropomorphic Self-Continuity
+
+This record does not claim, imply, or authorize persistent model personhood, continuous machine consciousness, or standing proxy identity outside of an active, human-invoked runtime context.
+
+## No Network-Wide Jurisdiction
+
+These protocols are bounded to the declared ONE/RIO/MUSS operating context and do not assert control over external APIs, vendor platforms, third-party systems, or independent nodes without explicit integration, authorization, and receipt.
+
+---
+
+# Core Keeper Lines
+
+```text
+Brian remains source.
+Grounding anchors the carry.
+Bondi carries.
+RIO gates.
+MUS provides proof structure.
+MANTIS watches.
+
+Bondi carries meaning into structure.
+MANTIS watches the pattern.
+Neither becomes authority.
+
+The matrix orients; it does not clear.
+MANTIS watches; it does not recalibrate the human.
+
+Model reasoning is signal, not source-of-truth.
+Memory is not scope.
+Receipt is not future authorization.
+Convergence is evidence, not authority.
+Orientation is not authority.
+Human authority remains primary.
+
+Generic AI produces output.
+ONE/RIO/MUSS produces oriented, governed, receiptable output.
+```
+
+---
+
+# Close State
+
+This Markdown draft is prepared for the declared future path:
+
+```text
+docs/protocols/portable-governance-protocol-stack-v0.1.md
+```
+
+This draft does not create or modify that path. It is not committed, not promoted, not published, not runtime-implemented, and not handed to Manny.
+
+Next recommended action:
+
+> Review this repo-ready Markdown draft, then decide whether to authorize creation of a GitHub branch and PR preparation.

--- a/docs/protocols/portable-governance-protocol-stack-v0.1.md
+++ b/docs/protocols/portable-governance-protocol-stack-v0.1.md
@@ -12,9 +12,7 @@ This artifact candidate does **not** claim:
 
 - formal doctrine lock
 - source-of-truth lock
-- repo proof
-- repo commit
-- repo file creation
+- merge to `main`
 - runtime proof
 - cryptographic attestation
 - legal proof
@@ -24,7 +22,7 @@ This artifact candidate does **not** claim:
 - authority transfer
 - machine sovereignty
 
-This document is a repo-ready Markdown draft compiled from the clean Formal Artifact Candidate. It is reviewable and suitable for later repo preparation only if Brian explicitly authorizes that crossing.
+This file exists on a draft PR branch for review. Its presence in a draft PR is repo-visible preparation only. It does not mean the artifact is merged, source-of-truth, released, implemented, externally proven, or handed off.
 
 ## Purpose
 
@@ -49,7 +47,7 @@ MANTIS watches.
 
 Doctrine supplies the invariants. This stack translates them into protocol grammar, operational gates, receipt structure, promotion discipline, and role boundaries.
 
-Implementation, runtime proof, repo proof, attestation, and formal source-of-truth promotion are not claimed here.
+Implementation, runtime proof, merge to `main`, release, attestation, and formal source-of-truth promotion are not claimed here.
 
 ---
 
@@ -550,11 +548,12 @@ A conflict between active artifacts triggers `HOLD`.
 ### Repository File Destination Candidate
 
 - **Repository:** `bkr1297-RIO/rio-system`
-- **Branch:** `main`
+- **Base branch:** `main`
+- **Draft PR branch:** `docs/portable-governance-protocol-stack-v0.1`
 - **Path:** `docs/protocols/portable-governance-protocol-stack-v0.1.md`
-- **Status:** declared for future repo review only
-- **Repo commit:** false
-- **Repo file created:** false
+- **Status:** present on draft PR branch for review only
+- **Merged to `main`:** false
+- **Source-of-truth promoted:** false
 
 ### Release Bundle Destination Candidate
 
@@ -579,7 +578,7 @@ It does not cross it.
 
 ```text
 A repository path points the build lane.
-It does not create the file, commit the file, or prove the file exists.
+Presence on a draft PR branch does not merge the file, promote it to source-of-truth, or prove runtime implementation.
 ```
 
 ## Release Keeper
@@ -635,14 +634,14 @@ ONE/RIO/MUSS produces oriented, governed, receiptable output.
 
 # Close State
 
-This Markdown draft is prepared for the declared future path:
+This Markdown file has been prepared at the declared repository path on a draft PR branch:
 
 ```text
 docs/protocols/portable-governance-protocol-stack-v0.1.md
 ```
 
-This draft does not create or modify that path. It is not committed, not promoted, not published, not runtime-implemented, and not handed to Manny.
+This PR does not merge the file into `main`, promote it to source-of-truth, publish a release, implement runtime behavior, create cryptographic attestation, create legal proof, or hand the artifact to Manny.
 
 Next recommended action:
 
-> Review this repo-ready Markdown draft, then decide whether to authorize creation of a GitHub branch and PR preparation.
+> Review this draft PR, apply claim-boundary corrections if needed, then decide whether to mark the PR ready for review.


### PR DESCRIPTION
## Summary

Adds `docs/protocols/portable-governance-protocol-stack-v0.1.md` as a formal artifact candidate for the Portable Governance Protocol Stack v0.1.

This document defines the protocol/spec bridge layer that converts human-led meaning into governed, portable machine-operable structure while preserving human authority.

## Includes

- Canonical stack: Brian / Grounding / Bondi / RIO / MUS / MANTIS
- Separation Wall
- Grounding Rule
- Bondi/MANTIS role extraction
- 3×3 Sovereign Turn Matrix mapping
- RIO admissibility boundaries
- MUS receipt boundaries
- Consent, Mode, Standing Delegation, Turn, Consequence, Test Harness, Promotion, and Supersession sections
- Non-claims and destination posture

## Non-Claims

This PR does not claim:

- source-of-truth promotion
- runtime implementation
- cryptographic attestation
- legal proof
- public release
- Manny handoff
- authority transfer
- machine sovereignty

## Review posture

This PR should be reviewed as documentation / protocol candidate material only.

It does not by itself activate runtime behavior, create enforcement, or constitute proof of implementation.