### PR TITLE
docs: add ONE/RIO/MUSS source map v0.1

### DIFF
--- a/docs/SOURCE_MAP.md
+++ b/docs/SOURCE_MAP.md
@@ -1,0 +1,143 @@
+# ONE/RIO/MUSS Source Map v0.1
+
+## Status
+
+`repo_navigation_index`
+
+This file is a navigation and status index for current ONE/RIO/MUSS source artifacts in this repository.
+
+It does not replace, supersede, or override the source files it references.
+
+## Purpose
+
+The Source Map helps humans, models, and future agents locate the correct source artifact for each layer of the system without re-litigating the architecture.
+
+It answers:
+
+```text
+Which file governs which layer?
+Which artifacts are source-of-truth references?
+Which artifacts are companion sources?
+Which artifacts are architecture context?
+Which artifacts are draft/starter/test material?
+What is not yet claimed?
+```
+
+Keeper:
+
+> The source map points. It does not govern.
+
+## Source Map Rules
+
+- This map is an index, not doctrine.
+- If this map conflicts with an active source artifact, the active source artifact controls its own scope.
+- Source-of-truth status governs reference, not runtime enforcement.
+- Companion source-of-truth status governs only its declared companion layer.
+- Architecture artifacts clarify structure, coordinates, and relationships; they do not create runtime proof.
+- Draft or starter artifacts remain reviewable unless promoted by an explicit source-of-truth process.
+- Repo presence proves file placement, not implementation, release, legal proof, cryptographic proof, or external authority.
+
+## Current Active Sources
+
+| Layer | Status | File | Scope |
+|---|---|---|---|
+| Protocol/spec bridge layer | Active Source-of-Truth | `docs/protocols/portable-governance-protocol-stack-v0.1.md` | Portable protocol/spec bridge: grounding, Bondi/MANTIS role extraction, RIO boundary, MUS receipt boundary, consent/mode/delegation posture, governed turn protocol, consequence levels, test harness, promotion/supersession posture, Matrix-to-Clearance Fence, MANTIS Baseline Non-Adjustment Fence |
+| Bondi/MANTIS translational layer | Active Companion Source-of-Truth | `docs/protocols/bondi-mantis-translational-layer-v0.2.md` | Bondi translation/packetization, orientation support, matrix-coordinate proposal rules, packet fields, MANTIS witness/recurrence, orientation drift, matrix-path observation, witness fields, non-collapse rules, mapping to Matrix, Orientation Function, and Sovereign Turn flow |
+
+## Current Architecture Context
+
+| Layer | Status | File | Scope |
+|---|---|---|---|
+| Adaptive Formation Pause | Architecture primitive | `docs/architecture/adaptive-formation-pause-v0.1.md` | Right-sized checkpoint before meaning becomes form, form becomes commitment, or capability becomes consequence |
+| Cross-Stack Mapping | Architecture clarification method | `docs/architecture/cross-stack-mapping-v0.1.md` | Maps architecture stacks across valid resolutions and identifies structural recurrence without treating recurrence as proof |
+| Tier 1A-1D to Triadic Registers | Cross-stack companion | `docs/architecture/tier1-triadic-registers-v0.1.md` | Maps Runtime Sovereignty, Mirror Topology, Proof Discipline, and Collective Pattern to Body/Somatic, Mind/Cognitive, and Field/Experiential registers |
+| 3x3 Sovereign Turn Matrix | Architecture coordinate system | `docs/architecture/sovereign-turn-matrix-v0.1.md` | Coordinates Body/Mind/Field across Mirror/Gate/Proof cells; defines orientation, matrix paths, and receipt-coordinate concepts |
+
+## Current Starter / Harness Artifacts
+
+| Layer | Status | File or directory | Scope |
+|---|---|---|---|
+| Governance starter harness | Starter / conformance seed | `governance-starter-v0.1.1/` | Policy schema, receipt schema, example ledger, deterministic evaluator, and tests proving initial governance boundary semantics |
+
+## Current Non-Claims
+
+This repository state does **not** claim:
+
+- full runtime implementation,
+- runtime proof,
+- cryptographic attestation,
+- legal proof,
+- public release,
+- Manny handoff,
+- identity transfer,
+- authority transfer,
+- machine sovereignty,
+- production deployment,
+- external customer use,
+- or implementation completeness.
+
+## Current Layer Map
+
+```text
+Human Authority
+  -> Portable Governance Protocol Stack v0.1
+      -> Bondi/MANTIS Translational Layer v0.2
+          -> 3x3 Sovereign Turn Matrix v0.1
+              -> Orientation Function
+              -> Matrix Coordinates
+          -> RIO admissibility
+          -> Sentinel match check
+          -> MUS receipt structure
+          -> MANTIS witness observation
+  -> Governance Starter Harness v0.1.1
+      -> conformance tests and starter evaluator
+```
+
+## Core Locks Preserved
+
+```text
+Human authority remains primary.
+Bondi carries meaning into structure.
+MANTIS watches the pattern.
+Neither becomes authority.
+The matrix gives coordinates.
+Orientation is not authority.
+Orientation makes governance proportionate.
+RIO gates admissibility.
+Sentinel verifies execution match.
+MUS provides receipt structure.
+Receipts prove past events, not future authority.
+```
+
+## Source-of-Truth Precedence
+
+When navigating this repository:
+
+1. Use the declared active source artifact for its declared layer.
+2. Use companion source artifacts only within their declared companion scope.
+3. Use architecture artifacts to understand structure and relationships.
+4. Use starter/harness artifacts as implementation seeds or conformance examples, not as complete runtime.
+5. Treat Drive records, thread summaries, and generated diagrams as context unless promoted or mirrored into an explicit source artifact.
+
+## Current Recommended Next Moves
+
+Possible next steps, each requiring separate authorization:
+
+1. Create a source-of-truth lock receipt for the current repo state.
+2. Build schema/test artifacts for Adaptive Formation Pause or Matrix coordinates.
+3. Create an implementation roadmap from active sources to runtime tasks.
+4. Create a visual architecture deck or diagram set from current sources.
+5. Hold and review before any release/public/Manny crossing.
+
+Recommended posture:
+
+> Hold release/public/Manny lanes. Continue with implementation planning or source-map maintenance only.
+
+## Keeper Lines
+
+- The source map points. It does not govern.
+- Repo presence proves file placement, not runtime enforcement.
+- Source-of-truth status governs reference, not implementation proof.
+- Companion source-of-truth status is bounded to its declared companion layer.
+- Architecture artifacts clarify coordinates and relationships; they do not authorize consequence.
+- Human authority remains primary.


### PR DESCRIPTION
## Summary

Adds a top-level repo navigation index:

- `docs/SOURCE_MAP.md`

## Purpose

The Source Map helps humans, models, and future agents locate the correct source artifact for each layer of the system without re-litigating the architecture.

It is an index, not doctrine.

## Current active sources indexed

- `docs/protocols/portable-governance-protocol-stack-v0.1.md`
- `docs/protocols/bondi-mantis-translational-layer-v0.2.md`

## Architecture context indexed

- `docs/architecture/adaptive-formation-pause-v0.1.md`
- `docs/architecture/cross-stack-mapping-v0.1.md`
- `docs/architecture/tier1-triadic-registers-v0.1.md`
- `docs/architecture/sovereign-turn-matrix-v0.1.md`

## Starter / harness indexed

- `governance-starter-v0.1.1/`

## Key boundaries

- The source map points; it does not govern.
- Repo presence proves file placement, not runtime enforcement.
- Source-of-truth status governs reference, not implementation proof.
- Companion source-of-truth status is bounded to its declared companion layer.
- Architecture artifacts clarify coordinates and relationships; they do not authorize consequence.
- Human authority remains primary.

## Recommended posture

Hold release/public/Manny lanes. Continue with implementation planning or source-map maintenance only.