### PR TITLE
Add SPG-M runtime placement

### DIFF
--- a/docs/ONE_RIO_MUSS_MODULE_MAP.md
+++ b/docs/ONE_RIO_MUSS_MODULE_MAP.md
@@ -1,0 +1,90 @@
+# ONE/RIO/MUSS Module Map
+
+## Status
+
+Draft module map for current and planned ONE/RIO/MUSS components.
+
+This document is a placement aid. It does not create new runtime authority or claim that planned components are currently active.
+
+## Core Layers
+
+| Layer | Role | Runtime Status |
+|---|---|---|
+| ONE | Operating environment for human-led, machine-operated work | Not deployed in this repo |
+| RIO | Consequence and admissibility governance for execution | Partially implemented through gateway runtime |
+| MUSS | Sovereignty, consent, scope, memory, and proof boundaries | Partially represented through authorization and receipt flows |
+| MUS | Machine/operator layer under human sovereignty | Not a sovereign runtime actor |
+| SPG-M | Pattern Governance layer for ambiguous signals | Placement defined; active gateway integration not implemented |
+
+## Current RIO Runtime
+
+The current runtime map remains authoritative for what is running:
+
+```text
+Signal → Proposal → Policy → Authorization → Execution Gate → Execute → Receipt → Ledger
+```
+
+SPG-M is not a parallel execution path. It is a proposed pre-execution pattern-governance layer that can prepare, contain, or route pattern-derived signals before they affect runtime decisions.
+
+## Module Relationships
+
+| Module | Function | Must Not Do | Proof / Audit Link |
+|---|---|---|---|
+| Gateway | Receives intents and routes execution flow | Cannot bypass policy or authorization | Runtime logs + receipts |
+| Governor / Policy | Classifies risk and approval needs | Cannot execute | Policy result + receipt path |
+| Execution Gate | Enforces authorization and dispatches action | Cannot approve | Receipt + ledger |
+| Receipt System | Proves governed events | Cannot decide wisdom or authority | Cryptographic receipt |
+| Ledger | Stores hash-linked receipt entries | Cannot interpret meaning | Chain verification |
+| Pattern Corpus | Provides non-authoritative pattern context | Cannot decide or execute | Pattern validation records |
+| SPG-M | Governs ambiguous pattern signals before consequence | Cannot approve, execute, or create authority | Receipt-compatible outcomes through `rio-receipt-protocol` |
+
+## SPG-M Placement
+
+SPG-M sits between raw signal and consequential proposal formation:
+
+```text
+Raw signal / human context
+  → SPG-M pattern governance
+  → possible proposal context or containment
+  → RIO policy / authorization / execution boundary
+```
+
+SPG-M may produce:
+
+- signal capture,
+- fact/interpretation separation,
+- consequence class,
+- gate status,
+- containment/refusal status,
+- routing recommendation,
+- receipt-compatible metadata.
+
+SPG-M may not produce:
+
+- execution authorization,
+- direct action,
+- persistent memory without scope/consent governance,
+- identity or destiny claims,
+- proof that a pattern is true.
+
+## Receipt Boundary
+
+SPG-M receipt-compatible outcomes are implemented in `rio-receipt-protocol` as an additive profile adapter.
+
+Current mapping:
+
+- Proceed may map to `ALLOW` only when existing receipt checks pass.
+- Hold, contain, refuse, escalate, and fail map to `BLOCK`.
+- SPG-M details are metadata/check context, not authority.
+
+## Development Path
+
+1. Keep receipt proof in `rio-receipt-protocol`.
+2. Keep active execution control in the RIO gateway.
+3. Treat SPG-M as pre-execution pattern governance.
+4. Add SPG-M runtime only after intake, routing, and receipt boundaries are explicit.
+5. Preserve one execution boundary and one authority chain.
+
+## Summary
+
+ONE/RIO/MUSS separates environment, consequence governance, sovereignty boundaries, and machine operation. SPG-M adds a pattern-governance layer for ambiguous signals, but it remains non-sovereign and non-executing unless routed through the existing RIO pipeline.

--- a/docs/SPG_M_RUNTIME_PLACEMENT.md
+++ b/docs/SPG_M_RUNTIME_PLACEMENT.md
@@ -1,0 +1,88 @@
+# SPG-M Runtime Placement
+
+## Status
+
+Draft placement note for the ONE/RIO/MUSS system.
+
+SPG-M is not added here as an active runtime component. This note defines where SPG-M belongs when implemented and how it relates to the current RIO gateway, pattern corpus, and receipt layer.
+
+## Purpose
+
+SPG-M — Symbolic Pattern Governance Module — is a Pattern Governance layer for ambiguous, high-context, human-supplied signals before those signals influence machine action, memory, routing, escalation, or execution.
+
+In enterprise language, SPG-M governs pattern input before it becomes consequential system behavior.
+
+## Current Runtime Boundary
+
+The current RIO runtime pipeline remains:
+
+```text
+Signal → Proposal → Policy → Authorization → Execution Gate → Execute → Receipt → Ledger
+```
+
+SPG-M does not replace this pipeline.
+
+SPG-M belongs before execution authority is granted. Its role is to prepare, classify, contain, or route ambiguous pattern signals before they can influence an intent, policy decision, authorization path, memory update, or receipt event.
+
+## Placement
+
+```text
+Human / System Signal
+  → SPG-M Pattern Governance
+      → Signal capture
+      → Fact / interpretation separation
+      → Consequence classification
+      → Governance gates
+      → Containment / refusal / routing
+  → RIO Proposal / Policy / Authorization
+  → Execution Gate
+  → Receipt + Ledger
+```
+
+## Relationship to Existing Components
+
+| Component | SPG-M Relationship |
+|---|---|
+| Gateway | SPG-M may prepare or block pattern-derived inputs before they become gateway intents. |
+| Governor / Policy | SPG-M may provide consequence classification and gate results as context. It does not decide policy outcome. |
+| Execution Gate | SPG-M does not execute actions and does not bypass the gate. |
+| Receipt System | SPG-M outcomes can be expressed as receipt-compatible events in `rio-receipt-protocol`. |
+| Pattern Corpus | SPG-M aligns with non-authoritative pattern handling. Patterns may orient attention but do not decide. |
+| Ledger | SPG-M does not write ledger entries directly in this repo. Receipt-compatible events are proved by the receipt layer. |
+
+## Runtime Status
+
+| SPG-M Element | Status in `rio-system` |
+|---|---|
+| Doctrine | External/conceptual kernel exists |
+| Receipt-compatible profile | Implemented in `rio-receipt-protocol` |
+| Gateway integration | Not implemented |
+| Active policy evaluation | Not implemented |
+| Pattern memory integration | Not implemented |
+| Execution authority | Not allowed |
+
+## Non-Authority Rules
+
+SPG-M must preserve these boundaries:
+
+- Pattern signals do not create authority.
+- Interpretation is provisional.
+- Recurrence is not proof.
+- Machine interpretation is not authorization.
+- Pattern promotion does not authorize action.
+- Consequence class determines routing weight.
+- Class 3+ action must route to the appropriate RIO/MUSS governance path.
+
+## Integration Path
+
+A future implementation should proceed in this order:
+
+1. Add a gateway-side SPG-M intake route or middleware in non-executing mode.
+2. Produce SPG-M gate results as structured context.
+3. Route consequential outputs into existing RIO policy and authorization flow.
+4. Generate receipt-compatible SPG-M events through the receipt layer.
+5. Keep pattern storage separate from the ledger unless a receipt event is produced.
+
+## Summary
+
+SPG-M is a pre-execution pattern-governance layer. It may classify and contain ambiguous signals, but it cannot approve, execute, or create authority. Execution remains governed by the existing RIO pipeline and proven through receipts.


### PR DESCRIPTION
Adds SPG-M placement docs for the ONE/RIO/MUSS runtime map. Docs only.