### PR TITLE
Test SPG-M intake route

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -9,7 +9,7 @@
     "start": "node server.mjs",
     "dev": "node --watch server.mjs",
     "test": "node --test tests/gateway.test.mjs",
-    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs"
+    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/tests/spgm-route.test.mjs
+++ b/gateway/tests/spgm-route.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * SPG-M Route Tests
+ *
+ * Tests the non-executing /spgm/intake route in isolation with a mock principal.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import spgmRoutes from "../routes/spgm.mjs";
+
+let server;
+let baseUrl;
+
+function buildTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Mock resolved principal for route-level testing only.
+  app.use((req, res, next) => {
+    req.principal = {
+      principal_id: "test-proposer",
+      primary_role: "proposer",
+      secondary_roles: [],
+      status: "active",
+    };
+    next();
+  });
+
+  app.use("/spgm", spgmRoutes);
+  return app;
+}
+
+async function post(path, body) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return { status: res.status, data };
+}
+
+describe("SPG-M Intake Route", () => {
+  before(async () => {
+    const app = buildTestApp();
+    await new Promise((resolve) => {
+      server = app.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("returns non-executing private reflection result", async () => {
+    const { status, data } = await post("/spgm/intake", {
+      signal: {
+        literal_description: "Human reports a recurring symbol during private journaling.",
+        signal_type: "pattern",
+      },
+      proposed_use: {
+        use_type: "reflect",
+        affected_parties: [],
+      },
+      machine_assistance: {
+        used: false,
+        role: null,
+      },
+    });
+
+    assert.equal(status, 200);
+    assert.equal(data.status, "ok");
+    assert.equal(data.mode, "non_executing");
+    assert.equal(data.spgm_result.consequence_class, 1);
+    assert.equal(data.spgm_result.status, "record");
+    assert.equal(data.routing.rio_required, false);
+  });
+
+  it("routes relational output without execution authority", async () => {
+    const { status, data } = await post("/spgm/intake", {
+      signal: {
+        literal_description: "Human reports a recurring relational pattern involving another person.",
+        signal_type: "relational",
+      },
+      proposed_use: {
+        use_type: "propose",
+        proposed_action: "start_conversation",
+        affected_parties: ["other_person"],
+        known_domains: ["relationship"],
+      },
+      machine_assistance: {
+        used: true,
+        role: "classification",
+      },
+    });
+
+    assert.equal(status, 200);
+    assert.equal(data.mode, "non_executing");
+    assert.equal(data.spgm_result.consequence_class, 3);
+    assert.equal(data.spgm_result.status, "route");
+    assert.equal(data.routing.rio_required, true);
+    assert.equal(data.routing.muss_required, true);
+    assert.match(data.authority_boundary, /does not approve/);
+  });
+
+  it("fails closed on invalid intake packets", async () => {
+    const { status, data } = await post("/spgm/intake", {
+      proposed_use: {
+        use_type: "reflect",
+      },
+    });
+
+    assert.equal(status, 400);
+    assert.equal(data.status, "hold");
+    assert.equal(data.mode, "non_executing");
+    assert.equal(data.error, "SPGM_INTAKE_VALIDATION_FAILED");
+    assert.ok(Array.isArray(data.errors));
+    assert.equal(data.spgm_result.status, "hold");
+    assert.equal(data.next_step, "containment");
+  });
+});


### PR DESCRIPTION
Adds isolated route tests for the non-executing SPG-M intake endpoint.