### PR TITLE
Add SPG-M policy adapter

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -9,7 +9,7 @@
     "start": "node server.mjs",
     "dev": "node --watch server.mjs",
     "test": "node --test tests/gateway.test.mjs",
-    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs"
+    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/spgm/policy-adapter.mjs
+++ b/gateway/spgm/policy-adapter.mjs
@@ -1,0 +1,127 @@
+/**
+ * SPG-M Policy Adapter
+ *
+ * Converts SPG-M policy_context into non-authorizing RIO review metadata.
+ * This adapter does not evaluate policy, approve actions, deny actions,
+ * issue tokens, execute actions, write ledger entries, generate receipts,
+ * or create memory.
+ */
+
+const REQUIRED_FALSE_POLICY_USE_FLAGS = [
+  "may_create_authorization",
+  "may_create_execution",
+  "may_write_ledger",
+  "may_create_memory",
+];
+
+const REQUIRED_TRUE_BOUNDARY_FLAGS = [
+  "non_executing",
+  "signal_not_command",
+  "interpretation_provisional",
+  "machine_boundary_preserved",
+];
+
+function hasObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateSpgmPolicyContext(policyContext = {}) {
+  const errors = [];
+
+  if (!hasObject(policyContext)) {
+    return {
+      valid: false,
+      errors: ["policy_context must be an object"],
+    };
+  }
+
+  if (policyContext.context_type !== "spgm_policy_context") {
+    errors.push("policy_context.context_type must be spgm_policy_context");
+  }
+
+  if (policyContext.mode !== "non_executing") {
+    errors.push("policy_context.mode must be non_executing");
+  }
+
+  if (!hasObject(policyContext.policy_use)) {
+    errors.push("policy_context.policy_use must be an object");
+  } else {
+    for (const flag of REQUIRED_FALSE_POLICY_USE_FLAGS) {
+      if (policyContext.policy_use[flag] !== false) {
+        errors.push(`policy_context.policy_use.${flag} must be false`);
+      }
+    }
+  }
+
+  if (!hasObject(policyContext.boundary_flags)) {
+    errors.push("policy_context.boundary_flags must be an object");
+  } else {
+    for (const flag of REQUIRED_TRUE_BOUNDARY_FLAGS) {
+      if (policyContext.boundary_flags[flag] !== true) {
+        errors.push(`policy_context.boundary_flags.${flag} must be true`);
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function buildSpgmPolicyReviewMetadata(policyContext = {}) {
+  const validation = validateSpgmPolicyContext(policyContext);
+
+  if (!validation.valid) {
+    return {
+      accepted: false,
+      context_type: "spgm_policy_review_metadata",
+      mode: "non_executing",
+      errors: validation.errors,
+      policy_effect: {
+        may_inform_policy_review: false,
+        may_authorize: false,
+        may_execute: false,
+        may_write_ledger: false,
+        may_create_memory: false,
+      },
+      required_action: "reject_or_contain_context",
+    };
+  }
+
+  const spgm = policyContext.spgm || {};
+  const routing = policyContext.routing || {};
+  const boundaryFlags = policyContext.boundary_flags || {};
+
+  return {
+    accepted: true,
+    context_type: "spgm_policy_review_metadata",
+    mode: "non_executing",
+    source: policyContext.source || null,
+    consequence_class: Number.isInteger(spgm.consequence_class) ? spgm.consequence_class : null,
+    spgm_status: spgm.status || "unknown",
+    rio_required: routing.rio_required === true,
+    muss_required: routing.muss_required === true,
+    receipt_event_recommended: boundaryFlags.receipt_event_recommended === true,
+    receipt_decision_hint: boundaryFlags.receipt_decision_hint || null,
+    gates: spgm.gates || {},
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_authorize: false,
+      may_execute: false,
+      may_write_ledger: false,
+      may_create_memory: false,
+    },
+    required_action: routing.rio_required === true
+      ? "rio_review_required"
+      : "available_as_context_only",
+    authority_boundary: "SPG-M review metadata may inform RIO policy review, but it cannot authorize, execute, issue tokens, write ledger entries, generate receipts, or create memory.",
+  };
+}
+
+export function buildSpgmPolicyReviewFromIntakeResult(intakeResult = {}) {
+  if (!hasObject(intakeResult.policy_context)) {
+    return buildSpgmPolicyReviewMetadata(null);
+  }
+  return buildSpgmPolicyReviewMetadata(intakeResult.policy_context);
+}

--- a/gateway/tests/spgm-policy-adapter.test.mjs
+++ b/gateway/tests/spgm-policy-adapter.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * SPG-M Policy Adapter Tests
+ *
+ * Tests conversion of SPG-M policy_context into non-authorizing
+ * RIO review metadata.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { processSpgmIntake } from "../spgm/intake.mjs";
+import {
+  validateSpgmPolicyContext,
+  buildSpgmPolicyReviewMetadata,
+  buildSpgmPolicyReviewFromIntakeResult,
+} from "../spgm/policy-adapter.mjs";
+
+const relationalPacket = {
+  signal: {
+    literal_description: "Human reports a recurring relational pattern involving another person.",
+    signal_type: "relational",
+    source_context: "conversation planning",
+    recurrence_claimed: true,
+  },
+  proposed_use: {
+    use_type: "propose",
+    proposed_action: "start_conversation",
+    affected_parties: ["other_person"],
+    known_domains: ["relationship"],
+  },
+  machine_assistance: {
+    used: true,
+    role: "classification",
+  },
+};
+
+describe("SPG-M Policy Adapter", () => {
+  it("accepts valid SPG-M policy context", () => {
+    const intakeResult = processSpgmIntake(relationalPacket);
+    const validation = validateSpgmPolicyContext(intakeResult.policy_context);
+
+    assert.equal(validation.valid, true);
+    assert.deepEqual(validation.errors, []);
+  });
+
+  it("rejects missing policy context", () => {
+    const validation = validateSpgmPolicyContext(null);
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.errors.includes("policy_context must be an object"));
+  });
+
+  it("rejects policy context that could create authorization", () => {
+    const intakeResult = processSpgmIntake(relationalPacket);
+    const unsafeContext = structuredClone(intakeResult.policy_context);
+    unsafeContext.policy_use.may_create_authorization = true;
+
+    const validation = validateSpgmPolicyContext(unsafeContext);
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.errors.includes("policy_context.policy_use.may_create_authorization must be false"));
+  });
+
+  it("rejects policy context that is not non-executing", () => {
+    const intakeResult = processSpgmIntake(relationalPacket);
+    const unsafeContext = structuredClone(intakeResult.policy_context);
+    unsafeContext.mode = "executing";
+
+    const validation = validateSpgmPolicyContext(unsafeContext);
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.errors.includes("policy_context.mode must be non_executing"));
+  });
+
+  it("builds accepted review metadata without authority", () => {
+    const intakeResult = processSpgmIntake(relationalPacket);
+    const review = buildSpgmPolicyReviewMetadata(intakeResult.policy_context);
+
+    assert.equal(review.accepted, true);
+    assert.equal(review.context_type, "spgm_policy_review_metadata");
+    assert.equal(review.mode, "non_executing");
+    assert.equal(review.consequence_class, 3);
+    assert.equal(review.rio_required, true);
+    assert.equal(review.muss_required, true);
+    assert.equal(review.policy_effect.may_inform_policy_review, true);
+    assert.equal(review.policy_effect.may_authorize, false);
+    assert.equal(review.policy_effect.may_execute, false);
+    assert.equal(review.policy_effect.may_write_ledger, false);
+    assert.equal(review.policy_effect.may_create_memory, false);
+    assert.equal(review.required_action, "rio_review_required");
+  });
+
+  it("rejects unsafe review metadata", () => {
+    const review = buildSpgmPolicyReviewMetadata({
+      context_type: "spgm_policy_context",
+      mode: "executing",
+      policy_use: {
+        may_create_authorization: true,
+        may_create_execution: false,
+        may_write_ledger: false,
+        may_create_memory: false,
+      },
+      boundary_flags: {
+        non_executing: false,
+        signal_not_command: true,
+        interpretation_provisional: true,
+        machine_boundary_preserved: true,
+      },
+    });
+
+    assert.equal(review.accepted, false);
+    assert.equal(review.policy_effect.may_inform_policy_review, false);
+    assert.equal(review.policy_effect.may_authorize, false);
+    assert.equal(review.required_action, "reject_or_contain_context");
+  });
+
+  it("builds review metadata from intake result", () => {
+    const intakeResult = processSpgmIntake(relationalPacket);
+    const review = buildSpgmPolicyReviewFromIntakeResult(intakeResult);
+
+    assert.equal(review.accepted, true);
+    assert.equal(review.source.route, "/spgm/intake");
+    assert.match(review.authority_boundary, /cannot authorize/);
+  });
+});


### PR DESCRIPTION
Adds a pure SPG-M policy adapter that validates context as non-authorizing review metadata.