### PR TITLE
Add SPG-M policy bridge helper

### DIFF
--- a/gateway/governance/spgm-policy-bridge.mjs
+++ b/gateway/governance/spgm-policy-bridge.mjs
@@ -1,0 +1,160 @@
+/**
+ * SPG-M Policy Bridge
+ *
+ * Pure RIO-side consumer for SPG-M policy review metadata.
+ *
+ * This module does not evaluate full RIO policy, approve actions,
+ * deny actions by itself, execute actions, issue tokens, write ledger entries,
+ * generate receipts, or create memory.
+ *
+ * It can only:
+ * - validate SPG-M review metadata as non-authorizing context,
+ * - add audit checks,
+ * - conservatively upgrade AUTO_APPROVE to REQUIRE_HUMAN when SPG-M marks
+ *   RIO review required.
+ */
+
+const GOVERNANCE_DECISIONS = Object.freeze({
+  AUTO_APPROVE: "AUTO_APPROVE",
+  AUTO_DENY: "AUTO_DENY",
+  REQUIRE_HUMAN: "REQUIRE_HUMAN",
+  REQUIRE_QUORUM: "REQUIRE_QUORUM",
+  REQUIRE_UNANIMOUS: "REQUIRE_UNANIMOUS",
+  MAINTENANCE_PAUSED: "MAINTENANCE_PAUSED",
+});
+
+const RISK_ORDER = Object.freeze(["NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL"]);
+
+function maxRisk(currentRisk, minimumRisk) {
+  const currentIndex = RISK_ORDER.indexOf(currentRisk);
+  const minimumIndex = RISK_ORDER.indexOf(minimumRisk);
+  if (currentIndex === -1) return minimumRisk;
+  if (minimumIndex === -1) return currentRisk;
+  return RISK_ORDER[Math.max(currentIndex, minimumIndex)];
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateSpgmPolicyReviewMetadata(policyReview = {}) {
+  const errors = [];
+
+  if (!isObject(policyReview)) {
+    return {
+      valid: false,
+      errors: ["spgm_policy_review must be an object"],
+    };
+  }
+
+  if (policyReview.context_type !== "spgm_policy_review_metadata") {
+    errors.push("spgm_policy_review.context_type must be spgm_policy_review_metadata");
+  }
+
+  if (policyReview.mode !== "non_executing") {
+    errors.push("spgm_policy_review.mode must be non_executing");
+  }
+
+  if (policyReview.accepted !== true) {
+    errors.push("spgm_policy_review.accepted must be true");
+  }
+
+  if (!isObject(policyReview.policy_effect)) {
+    errors.push("spgm_policy_review.policy_effect must be an object");
+  } else {
+    if (policyReview.policy_effect.may_authorize !== false) {
+      errors.push("spgm_policy_review.policy_effect.may_authorize must be false");
+    }
+    if (policyReview.policy_effect.may_execute !== false) {
+      errors.push("spgm_policy_review.policy_effect.may_execute must be false");
+    }
+    if (policyReview.policy_effect.may_write_ledger !== false) {
+      errors.push("spgm_policy_review.policy_effect.may_write_ledger must be false");
+    }
+    if (policyReview.policy_effect.may_create_memory !== false) {
+      errors.push("spgm_policy_review.policy_effect.may_create_memory must be false");
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function buildSpgmPolicyBridgeCheck(policyReview = {}) {
+  const validation = validateSpgmPolicyReviewMetadata(policyReview);
+
+  if (!validation.valid) {
+    return {
+      check: "spgm_policy_review_context",
+      passed: false,
+      effect: "ignored_or_contained",
+      errors: validation.errors,
+    };
+  }
+
+  return {
+    check: "spgm_policy_review_context",
+    passed: true,
+    mode: "non_executing",
+    consequence_class: policyReview.consequence_class ?? null,
+    spgm_status: policyReview.spgm_status || "unknown",
+    rio_required: policyReview.rio_required === true,
+    muss_required: policyReview.muss_required === true,
+    receipt_event_recommended: policyReview.receipt_event_recommended === true,
+    effect: policyReview.rio_required === true
+      ? "review_required"
+      : "context_only",
+  };
+}
+
+export function applySpgmPolicyBridge(governanceDecision = {}, policyReview = null) {
+  if (!policyReview) {
+    return {
+      ...governanceDecision,
+      checks: [
+        ...(governanceDecision.checks || []),
+        {
+          check: "spgm_policy_review_context",
+          passed: true,
+          effect: "not_present",
+        },
+      ],
+    };
+  }
+
+  const check = buildSpgmPolicyBridgeCheck(policyReview);
+  const checks = [...(governanceDecision.checks || []), check];
+
+  if (!check.passed) {
+    return {
+      ...governanceDecision,
+      checks,
+      spgm_policy_context_status: "rejected_or_contained",
+    };
+  }
+
+  if (
+    policyReview.rio_required === true &&
+    governanceDecision.governance_decision === GOVERNANCE_DECISIONS.AUTO_APPROVE
+  ) {
+    return {
+      ...governanceDecision,
+      governance_decision: GOVERNANCE_DECISIONS.REQUIRE_HUMAN,
+      status: "requires_approval",
+      reason: "SPG-M context requires RIO review before execution.",
+      requires_approval: true,
+      risk_tier: maxRisk(governanceDecision.risk_tier, "MEDIUM"),
+      risk_level: maxRisk(governanceDecision.risk_tier, "MEDIUM").toLowerCase(),
+      checks,
+      spgm_policy_context_status: "escalated_to_review",
+    };
+  }
+
+  return {
+    ...governanceDecision,
+    checks,
+    spgm_policy_context_status: "accepted_as_context",
+  };
+}

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -9,7 +9,7 @@
     "start": "node server.mjs",
     "dev": "node --watch server.mjs",
     "test": "node --test tests/gateway.test.mjs",
-    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs"
+    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/tests/spgm-policy-bridge.test.mjs
+++ b/gateway/tests/spgm-policy-bridge.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * SPG-M Policy Bridge Tests
+ *
+ * Tests the pure RIO-side consumer for SPG-M review metadata.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateSpgmPolicyReviewMetadata,
+  buildSpgmPolicyBridgeCheck,
+  applySpgmPolicyBridge,
+} from "../governance/spgm-policy-bridge.mjs";
+
+function basePolicyReview(overrides = {}) {
+  return {
+    accepted: true,
+    context_type: "spgm_policy_review_metadata",
+    mode: "non_executing",
+    consequence_class: 3,
+    spgm_status: "route",
+    rio_required: true,
+    muss_required: true,
+    receipt_event_recommended: true,
+    receipt_decision_hint: "BLOCK",
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_authorize: false,
+      may_execute: false,
+      may_write_ledger: false,
+      may_create_memory: false,
+    },
+    required_action: "rio_review_required",
+    ...overrides,
+  };
+}
+
+function baseDecision(overrides = {}) {
+  return {
+    governance_decision: "AUTO_APPROVE",
+    status: "auto_approved",
+    reason: "Action is within allowed permissions and meets all thresholds.",
+    requires_approval: false,
+    risk_tier: "LOW",
+    risk_level: "low",
+    checks: [{ check: "action_class_match", passed: true }],
+    ...overrides,
+  };
+}
+
+describe("SPG-M Policy Bridge", () => {
+  it("accepts valid non-executing SPG-M review metadata", () => {
+    const validation = validateSpgmPolicyReviewMetadata(basePolicyReview());
+
+    assert.equal(validation.valid, true);
+    assert.deepEqual(validation.errors, []);
+  });
+
+  it("rejects metadata that can authorize", () => {
+    const validation = validateSpgmPolicyReviewMetadata(basePolicyReview({
+      policy_effect: {
+        may_inform_policy_review: true,
+        may_authorize: true,
+        may_execute: false,
+        may_write_ledger: false,
+        may_create_memory: false,
+      },
+    }));
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.errors.includes("spgm_policy_review.policy_effect.may_authorize must be false"));
+  });
+
+  it("rejects executing metadata", () => {
+    const validation = validateSpgmPolicyReviewMetadata(basePolicyReview({
+      mode: "executing",
+    }));
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.errors.includes("spgm_policy_review.mode must be non_executing"));
+  });
+
+  it("builds an accepted policy bridge check", () => {
+    const check = buildSpgmPolicyBridgeCheck(basePolicyReview());
+
+    assert.equal(check.check, "spgm_policy_review_context");
+    assert.equal(check.passed, true);
+    assert.equal(check.mode, "non_executing");
+    assert.equal(check.rio_required, true);
+    assert.equal(check.effect, "review_required");
+  });
+
+  it("escalates AUTO_APPROVE to REQUIRE_HUMAN when RIO review is required", () => {
+    const bridged = applySpgmPolicyBridge(baseDecision(), basePolicyReview());
+
+    assert.equal(bridged.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(bridged.status, "requires_approval");
+    assert.equal(bridged.requires_approval, true);
+    assert.equal(bridged.risk_tier, "MEDIUM");
+    assert.equal(bridged.spgm_policy_context_status, "escalated_to_review");
+    assert.ok(bridged.checks.some((check) => check.check === "spgm_policy_review_context"));
+  });
+
+  it("does not downgrade existing REQUIRE_HUMAN", () => {
+    const bridged = applySpgmPolicyBridge(baseDecision({
+      governance_decision: "REQUIRE_HUMAN",
+      status: "requires_approval",
+      requires_approval: true,
+      risk_tier: "HIGH",
+      risk_level: "high",
+    }), basePolicyReview({ rio_required: false }));
+
+    assert.equal(bridged.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(bridged.risk_tier, "HIGH");
+    assert.equal(bridged.spgm_policy_context_status, "accepted_as_context");
+  });
+
+  it("does not override AUTO_DENY", () => {
+    const bridged = applySpgmPolicyBridge(baseDecision({
+      governance_decision: "AUTO_DENY",
+      status: "blocked",
+      requires_approval: false,
+      risk_tier: "CRITICAL",
+      risk_level: "critical",
+    }), basePolicyReview());
+
+    assert.equal(bridged.governance_decision, "AUTO_DENY");
+    assert.equal(bridged.status, "blocked");
+    assert.equal(bridged.risk_tier, "CRITICAL");
+  });
+
+  it("rejects unsafe context without changing the decision", () => {
+    const bridged = applySpgmPolicyBridge(baseDecision(), basePolicyReview({
+      policy_effect: {
+        may_inform_policy_review: true,
+        may_authorize: true,
+        may_execute: false,
+        may_write_ledger: false,
+        may_create_memory: false,
+      },
+    }));
+
+    assert.equal(bridged.governance_decision, "AUTO_APPROVE");
+    assert.equal(bridged.spgm_policy_context_status, "rejected_or_contained");
+    assert.ok(bridged.checks.some((check) => check.passed === false));
+  });
+
+  it("adds a not-present check when no SPG-M review metadata exists", () => {
+    const bridged = applySpgmPolicyBridge(baseDecision(), null);
+
+    assert.equal(bridged.governance_decision, "AUTO_APPROVE");
+    assert.ok(bridged.checks.some((check) => check.effect === "not_present"));
+  });
+});


### PR DESCRIPTION
Adds a pure SPG-M policy bridge helper and tests. No live policy wiring.