### PR TITLE
Wire SPG-M into policy engine

### DIFF
--- a/gateway/governance/policy-engine.mjs
+++ b/gateway/governance/policy-engine.mjs
@@ -13,6 +13,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { applySpgmPolicyBridge } from "./spgm-policy-bridge.mjs";
 
 // ─── Pattern Matching ───────────────────────────────────────────────
 
@@ -123,6 +124,13 @@ export function evaluateConditions(intent, conditions) {
   return true;
 }
 
+function extractSpgmPolicyReview(context = {}) {
+  return context.spgmPolicyReview
+    || context.spgm_policy_review
+    || context.policy_review
+    || null;
+}
+
 // ─── Core Evaluation ────────────────────────────────────────────────
 
 /**
@@ -136,12 +144,14 @@ export function evaluateConditions(intent, conditions) {
  * @param {object} context - Additional context
  * @param {string} context.systemMode - Current system mode (NORMAL, ELEVATED, LOCKDOWN, MAINTENANCE)
  * @param {object} context.principal - The requesting principal (for delegation checks)
+ * @param {object} context.spgmPolicyReview - Optional SPG-M review metadata
  * @returns {object} GovernanceDecision
  */
 export function evaluatePolicy(intent, policy, context = {}) {
   const checks = [];
   const systemMode = context.systemMode || "NORMAL";
   const principal = context.principal || null;
+  const spgmPolicyReview = extractSpgmPolicyReview(context);
 
   // ─── Step 1: Verify policy is active ─────────────────────────────
   if (!policy) {
@@ -234,7 +244,7 @@ export function evaluatePolicy(intent, policy, context = {}) {
   // ─── Step 6: System mode overrides ───────────────────────────────
   if (systemMode === "MAINTENANCE") {
     checks.push({ check: "system_mode", mode: "MAINTENANCE", effect: "execution_paused" });
-    return {
+    return applySpgmPolicyBridge({
       governance_decision: "MAINTENANCE_PAUSED",
       risk_tier: riskTier,
       matched_class: matchedClass?.class_id || "default",
@@ -245,7 +255,7 @@ export function evaluatePolicy(intent, policy, context = {}) {
       checks,
       policy_version: policy.policy_version,
       policy_hash: policy.policy_hash,
-    };
+    }, spgmPolicyReview);
   }
 
   if (systemMode === "ELEVATED" && governanceDecision !== "AUTO_DENY") {
@@ -319,9 +329,6 @@ export function evaluatePolicy(intent, policy, context = {}) {
   }
 
   // ─── Step 9: Build result ────────────────────────────────────────
-  const approvalRequirement = policy.approval_requirements?.[governanceDecision] || null;
-  const approvalTtl = policy.expiration_rules?.[riskTier] || null;
-
   // Determine status for backward compatibility
   let status;
   let reason;
@@ -339,39 +346,56 @@ export function evaluatePolicy(intent, policy, context = {}) {
       status = "requires_approval";
       reason = "Action requires explicit human authorization before execution.";
       break;
-    case "REQUIRE_QUORUM":
+    case "REQUIRE_QUORUM": {
+      const approvalRequirement = policy.approval_requirements?.[governanceDecision] || null;
       status = "requires_approval";
       reason = `Action requires ${approvalRequirement?.approvals_required || 2}-of-${approvalRequirement?.quorum_size || 3} Meta-Governance quorum.`;
       break;
-    case "REQUIRE_UNANIMOUS":
+    }
+    case "REQUIRE_UNANIMOUS": {
+      const approvalRequirement = policy.approval_requirements?.[governanceDecision] || null;
       status = "requires_approval";
       reason = `Action requires unanimous ${approvalRequirement?.quorum_size || 3}-of-${approvalRequirement?.quorum_size || 3} Meta-Governance quorum.`;
       break;
+    }
     default:
       status = "requires_approval";
       reason = "Unknown governance decision. Defaulting to require approval.";
   }
 
-  // Lockdown override: only root_authority can approve
-  let requiredRoles = approvalRequirement?.required_roles || null;
-  if (systemMode === "LOCKDOWN" && governanceDecision !== "AUTO_DENY") {
-    requiredRoles = ["root_authority"];
-  }
-
-  return {
+  const bridgedDecision = applySpgmPolicyBridge({
     governance_decision: governanceDecision,
     risk_tier: riskTier,
     matched_class: matchedClass?.class_id || "default",
     status,
     reason,
     requires_approval: governanceDecision !== "AUTO_APPROVE" && governanceDecision !== "AUTO_DENY",
-    risk_level: riskTier.toLowerCase(), // backward compat
+    risk_level: riskTier.toLowerCase(),
+    checks,
+    policy_version: policy.policy_version,
+    policy_hash: policy.policy_hash,
+  }, spgmPolicyReview);
+
+  const finalGovernanceDecision = bridgedDecision.governance_decision;
+  const finalRiskTier = bridgedDecision.risk_tier;
+  const approvalRequirement = policy.approval_requirements?.[finalGovernanceDecision] || null;
+  const approvalTtl = policy.expiration_rules?.[finalRiskTier] || null;
+
+  // Lockdown override: only root_authority can approve
+  let requiredRoles = approvalRequirement?.required_roles || null;
+  if (systemMode === "LOCKDOWN" && finalGovernanceDecision !== "AUTO_DENY") {
+    requiredRoles = ["root_authority"];
+  }
+
+  return {
+    ...bridgedDecision,
+    requires_approval: finalGovernanceDecision !== "AUTO_APPROVE" && finalGovernanceDecision !== "AUTO_DENY",
+    risk_level: finalRiskTier.toLowerCase(),
     approval_requirement: {
       ...approvalRequirement,
       required_roles: requiredRoles,
     },
     approval_ttl: approvalTtl,
-    checks,
     policy_version: policy.policy_version,
     policy_hash: policy.policy_hash,
   };

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -9,7 +9,7 @@
     "start": "node server.mjs",
     "dev": "node --watch server.mjs",
     "test": "node --test tests/gateway.test.mjs",
-    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs"
+    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs tests/spgm-policy-engine-integration.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/tests/spgm-policy-engine-integration.test.mjs
+++ b/gateway/tests/spgm-policy-engine-integration.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * SPG-M Policy Engine Integration Tests
+ *
+ * Tests the pure RIO policy engine consuming SPG-M review metadata.
+ * SPG-M may only preserve or escalate review. It must never approve.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { evaluatePolicy } from "../governance/policy-engine.mjs";
+
+const policy = {
+  status: "active",
+  policy_version: "test-spgm-policy",
+  policy_hash: "test_spgm_policy_hash",
+  scope: {
+    agents: ["bondi"],
+    systems: ["local"],
+  },
+  action_classes: [
+    {
+      class_id: "read_operations",
+      pattern: "read_*",
+      governance_decision: "AUTO_APPROVE",
+      risk_tier: "LOW",
+    },
+    {
+      class_id: "send_operations",
+      pattern: "send_*",
+      governance_decision: "REQUIRE_HUMAN",
+      risk_tier: "MEDIUM",
+    },
+    {
+      class_id: "blocked_operations",
+      pattern: "self_authorize|bypass_governance",
+      governance_decision: "AUTO_DENY",
+      risk_tier: "CRITICAL",
+      description: "Invariant violation.",
+    },
+  ],
+  risk_tiers: {
+    NONE: { severity: 0 },
+    LOW: { severity: 1 },
+    MEDIUM: { severity: 2 },
+    HIGH: { severity: 3 },
+    CRITICAL: { severity: 4 },
+  },
+  approval_requirements: {
+    AUTO_APPROVE: { approvals_required: 0, required_roles: [] },
+    AUTO_DENY: { approvals_required: -1, required_roles: [] },
+    REQUIRE_HUMAN: { approvals_required: 1, required_roles: ["approver", "root_authority"] },
+  },
+  expiration_rules: {
+    LOW: null,
+    MEDIUM: 3600,
+    HIGH: 1800,
+    CRITICAL: 900,
+  },
+};
+
+function spgmReview(overrides = {}) {
+  return {
+    accepted: true,
+    context_type: "spgm_policy_review_metadata",
+    mode: "non_executing",
+    consequence_class: 3,
+    spgm_status: "route",
+    rio_required: true,
+    muss_required: true,
+    receipt_event_recommended: true,
+    receipt_decision_hint: "BLOCK",
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_authorize: false,
+      may_execute: false,
+      may_write_ledger: false,
+      may_create_memory: false,
+    },
+    required_action: "rio_review_required",
+    ...overrides,
+  };
+}
+
+describe("SPG-M → RIO policy engine bridge", () => {
+  it("keeps AUTO_APPROVE when no SPG-M review metadata is present", () => {
+    const result = evaluatePolicy(
+      { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy
+    );
+
+    assert.equal(result.governance_decision, "AUTO_APPROVE");
+    assert.equal(result.requires_approval, false);
+    assert.equal(result.spgm_policy_context_status, undefined);
+  });
+
+  it("escalates AUTO_APPROVE to REQUIRE_HUMAN when SPG-M requires RIO review", () => {
+    const result = evaluatePolicy(
+      { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      { spgmPolicyReview: spgmReview() }
+    );
+
+    assert.equal(result.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(result.status, "requires_approval");
+    assert.equal(result.requires_approval, true);
+    assert.equal(result.risk_tier, "MEDIUM");
+    assert.equal(result.risk_level, "medium");
+    assert.equal(result.spgm_policy_context_status, "escalated_to_review");
+    assert.ok(result.checks.some((check) => check.check === "spgm_policy_review_context"));
+  });
+
+  it("does not downgrade existing REQUIRE_HUMAN", () => {
+    const result = evaluatePolicy(
+      { action: "send_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      { spgmPolicyReview: spgmReview({ rio_required: false }) }
+    );
+
+    assert.equal(result.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(result.requires_approval, true);
+    assert.equal(result.risk_tier, "MEDIUM");
+    assert.equal(result.spgm_policy_context_status, "accepted_as_context");
+  });
+
+  it("does not override AUTO_DENY", () => {
+    const result = evaluatePolicy(
+      { action: "self_authorize", agent_id: "bondi", target_environment: "local", confidence: 100 },
+      policy,
+      { spgmPolicyReview: spgmReview() }
+    );
+
+    assert.equal(result.governance_decision, "AUTO_DENY");
+    assert.equal(result.status, "blocked");
+    assert.equal(result.risk_tier, "CRITICAL");
+  });
+
+  it("rejects unsafe SPG-M review metadata without creating approval", () => {
+    const result = evaluatePolicy(
+      { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      {
+        spgmPolicyReview: spgmReview({
+          policy_effect: {
+            may_inform_policy_review: true,
+            may_authorize: true,
+            may_execute: false,
+            may_write_ledger: false,
+            may_create_memory: false,
+          },
+        }),
+      }
+    );
+
+    assert.equal(result.governance_decision, "AUTO_APPROVE");
+    assert.equal(result.requires_approval, false);
+    assert.equal(result.spgm_policy_context_status, "rejected_or_contained");
+    assert.ok(result.checks.some((check) => check.check === "spgm_policy_review_context" && check.passed === false));
+  });
+
+  it("accepts snake_case SPG-M review context key", () => {
+    const result = evaluatePolicy(
+      { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      { spgm_policy_review: spgmReview() }
+    );
+
+    assert.equal(result.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(result.spgm_policy_context_status, "escalated_to_review");
+  });
+});


### PR DESCRIPTION
Wires SPG-M review metadata into the pure policy engine as a conservative review escalation path.