### PR TITLE
Add SPG-M policy review preview

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -9,7 +9,8 @@
     "start": "node server.mjs",
     "dev": "node --watch server.mjs",
     "test": "node --test tests/gateway.test.mjs",
-    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs tests/spgm-policy-engine-integration.test.mjs"
+    "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs tests/spgm-policy-engine-integration.test.mjs",
+    "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/routes/spgm.mjs
+++ b/gateway/routes/spgm.mjs
@@ -1,14 +1,16 @@
 /**
  * SPG-M Routes
  *
- * Non-executing intake route for ambiguous pattern-governance signals.
- * This route does not approve actions, issue execution tokens, dispatch
- * connectors, write ledger entries, or create persistent memory.
+ * Non-executing intake and review routes for ambiguous pattern-governance signals.
+ * These routes do not approve actions, issue execution tokens, dispatch
+ * connectors, write ledger entries, generate receipts, or create persistent memory.
  */
 import { Router } from "express";
 import { requireRole } from "../security/principals.mjs";
+import { getActivePolicy, getSystemMode } from "../governance/policy-store.mjs";
 import { processSpgmIntake } from "../spgm/intake.mjs";
 import { validateSpgmIntake, buildInvalidSpgmIntakeResponse } from "../spgm/schema.mjs";
+import { buildSpgmPolicyReviewPreview } from "../spgm/policy-review.mjs";
 
 const router = Router();
 
@@ -20,6 +22,7 @@ router.get("/status", (req, res) => {
     version: "0.1",
     routes: {
       "POST /spgm/intake": "Non-executing pattern-governance intake",
+      "POST /spgm/policy-review": "Non-executing RIO policy review preview with SPG-M metadata",
       "GET /spgm/status": "SPG-M capability/status report",
     },
     capabilities: {
@@ -29,6 +32,8 @@ router.get("/status", (req, res) => {
       routing_markers: true,
       receipt_event_recommendation: true,
       receipt_handoff_metadata: true,
+      policy_context_metadata: true,
+      policy_review_preview: true,
     },
     not_capable_of: [
       "approval",
@@ -39,7 +44,7 @@ router.get("/status", (req, res) => {
       "receipt_generation",
       "persistent_memory",
     ],
-    authority_boundary: "SPG-M is a non-executing intake and routing surface. It cannot approve, execute, issue tokens, write ledger entries, generate receipts, or create memory.",
+    authority_boundary: "SPG-M is a non-executing intake, routing, and review surface. It cannot approve, execute, issue tokens, write ledger entries, generate receipts, or create memory.",
   });
 });
 
@@ -68,6 +73,29 @@ router.post("/intake", requireRole("proposer", "approver", "auditor", "root_auth
     return res.status(500).json({
       error: "SPGM_INTAKE_ERROR",
       message: "Internal error processing SPG-M intake.",
+      fail_mode: "closed",
+    });
+  }
+});
+
+router.post("/policy-review", requireRole("proposer", "auditor", "root_authority"), (req, res) => {
+  try {
+    const { intent, policy, policy_review, spgm_policy_review, spgmPolicyReview, system_mode } = req.body || {};
+    const preview = buildSpgmPolicyReviewPreview({
+      intent,
+      policy: policy || getActivePolicy(),
+      policyReview: spgmPolicyReview || spgm_policy_review || policy_review || null,
+      systemMode: system_mode || getSystemMode(),
+      principal: req.principal || null,
+    });
+
+    const statusCode = preview.status === "ok" ? 200 : 400;
+    return res.status(statusCode).json(preview);
+  } catch (err) {
+    console.error(`[RIO Gateway] SPG-M policy-review error: ${err.message}`);
+    return res.status(500).json({
+      error: "SPGM_POLICY_REVIEW_ERROR",
+      message: "Internal error processing SPG-M policy-review preview.",
       fail_mode: "closed",
     });
   }

--- a/gateway/spgm/VERIFY_POLICY_REVIEW.md
+++ b/gateway/spgm/VERIFY_POLICY_REVIEW.md
@@ -1,0 +1,46 @@
+# SPG-M Policy Review Preview
+
+## Purpose
+
+This note verifies the non-executing SPG-M policy-review preview route.
+
+```text
+POST /spgm/policy-review
+```
+
+The route previews how SPG-M review metadata may affect RIO policy review.
+
+It does not create intents, approve actions, execute actions, write ledger entries, generate receipts, or create memory.
+
+## Test Commands
+
+From `gateway/`:
+
+```bash
+npm run test:spgm
+npm run test:spgm:policy-review
+```
+
+## Manual Preview
+
+```bash
+curl -X POST http://localhost:4400/spgm/policy-review \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <TOKEN>" \
+  --data @gateway/spgm/examples/policy-review.request.json
+```
+
+Expected result:
+
+- response mode is `non_executing`
+- review type is `spgm_policy_review_preview`
+- RIO may escalate review requirements
+- no action is approved
+- no execution path is opened
+- no proof artifact is created by this route
+
+## Boundary
+
+SPG-M policy review preview may increase governance weight.
+
+It may not reduce governance weight or create authority.

--- a/gateway/spgm/examples/policy-review.request.json
+++ b/gateway/spgm/examples/policy-review.request.json
@@ -1,0 +1,20 @@
+{
+  "intent": {
+    "action": "read_email",
+    "agent_id": "bondi",
+    "target_environment": "local",
+    "confidence": 90
+  },
+  "policy_review": {
+    "accepted": true,
+    "context_type": "spgm_policy_review_metadata",
+    "mode": "non_executing",
+    "consequence_class": 3,
+    "spgm_status": "route",
+    "rio_required": true,
+    "muss_required": true,
+    "receipt_event_recommended": true,
+    "receipt_decision_hint": "BLOCK",
+    "required_action": "rio_review_required"
+  }
+}

--- a/gateway/spgm/examples/policy-review.response.json
+++ b/gateway/spgm/examples/policy-review.response.json
@@ -1,0 +1,24 @@
+{
+  "status": "ok",
+  "mode": "non_executing",
+  "review_type": "spgm_policy_review_preview",
+  "spgm_policy_review_present": true,
+  "governance": {
+    "governance_decision": "REQUIRE_HUMAN",
+    "status": "requires_approval",
+    "risk_tier": "MEDIUM",
+    "risk_level": "medium",
+    "requires_approval": true,
+    "spgm_policy_context_status": "escalated_to_review"
+  },
+  "policy_effect": {
+    "may_inform_policy_review": true,
+    "may_create_intent": false,
+    "may_authorize": false,
+    "may_execute": false,
+    "may_issue_token": false,
+    "may_write_ledger": false,
+    "may_generate_receipt": false,
+    "may_create_memory": false
+  }
+}

--- a/gateway/spgm/policy-review.mjs
+++ b/gateway/spgm/policy-review.mjs
@@ -1,0 +1,69 @@
+/**
+ * SPG-M Policy Review Preview
+ *
+ * Non-executing preview bridge from SPG-M policy_review metadata into
+ * RIO's pure policy engine.
+ *
+ * This module does not create intents, approve actions, deny actions by itself,
+ * issue tokens, execute actions, write ledger entries, generate receipts, or
+ * create memory.
+ */
+import { evaluatePolicy } from "../governance/policy-engine.mjs";
+
+export function buildSpgmPolicyReviewPreview({
+  intent,
+  policy,
+  policyReview,
+  systemMode = "NORMAL",
+  principal = null,
+} = {}) {
+  if (!intent || typeof intent !== "object") {
+    return {
+      status: "hold",
+      mode: "non_executing",
+      error: "SPGM_POLICY_REVIEW_MISSING_INTENT",
+      message: "SPG-M policy review preview requires an intent object.",
+      authority_boundary: "No action may proceed from an invalid SPG-M policy review preview.",
+    };
+  }
+
+  const decision = evaluatePolicy(intent, policy || null, {
+    systemMode,
+    principal,
+    spgmPolicyReview: policyReview || null,
+  });
+
+  return {
+    status: "ok",
+    mode: "non_executing",
+    review_type: "spgm_policy_review_preview",
+    intent_summary: {
+      action: intent.action || null,
+      agent_id: intent.agent_id || null,
+      target_environment: intent.target_environment || intent.target_system || "local",
+    },
+    spgm_policy_review_present: Boolean(policyReview),
+    governance: {
+      governance_decision: decision.governance_decision,
+      status: decision.status,
+      risk_tier: decision.risk_tier,
+      risk_level: decision.risk_level,
+      matched_class: decision.matched_class,
+      requires_approval: decision.requires_approval,
+      reason: decision.reason,
+      spgm_policy_context_status: decision.spgm_policy_context_status || null,
+      checks: decision.checks || [],
+    },
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_create_intent: false,
+      may_authorize: false,
+      may_execute: false,
+      may_issue_token: false,
+      may_write_ledger: false,
+      may_generate_receipt: false,
+      may_create_memory: false,
+    },
+    authority_boundary: "SPG-M policy review preview may inform RIO review only. It cannot create intents, approve, execute, issue tokens, write ledger entries, generate receipts, or create memory.",
+  };
+}

--- a/gateway/tests/spgm-policy-review.test.mjs
+++ b/gateway/tests/spgm-policy-review.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * SPG-M Policy Review Preview Tests
+ *
+ * Tests the non-executing SPG-M policy-review preview helper.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSpgmPolicyReviewPreview } from "../spgm/policy-review.mjs";
+
+const policy = {
+  status: "active",
+  policy_version: "test-spgm-policy-review",
+  policy_hash: "test_spgm_policy_review_hash",
+  scope: {
+    agents: ["bondi"],
+    systems: ["local"],
+  },
+  action_classes: [
+    {
+      class_id: "read_operations",
+      pattern: "read_*",
+      governance_decision: "AUTO_APPROVE",
+      risk_tier: "LOW",
+    },
+    {
+      class_id: "send_operations",
+      pattern: "send_*",
+      governance_decision: "REQUIRE_HUMAN",
+      risk_tier: "MEDIUM",
+    },
+    {
+      class_id: "blocked_operations",
+      pattern: "self_authorize|bypass_governance",
+      governance_decision: "AUTO_DENY",
+      risk_tier: "CRITICAL",
+      description: "Invariant violation.",
+    },
+  ],
+  risk_tiers: {
+    NONE: { severity: 0 },
+    LOW: { severity: 1 },
+    MEDIUM: { severity: 2 },
+    HIGH: { severity: 3 },
+    CRITICAL: { severity: 4 },
+  },
+  approval_requirements: {
+    AUTO_APPROVE: { approvals_required: 0, required_roles: [] },
+    AUTO_DENY: { approvals_required: -1, required_roles: [] },
+    REQUIRE_HUMAN: { approvals_required: 1, required_roles: ["approver", "root_authority"] },
+  },
+  expiration_rules: {
+    LOW: null,
+    MEDIUM: 3600,
+    HIGH: 1800,
+    CRITICAL: 900,
+  },
+};
+
+function spgmReview(overrides = {}) {
+  return {
+    accepted: true,
+    context_type: "spgm_policy_review_metadata",
+    mode: "non_executing",
+    consequence_class: 3,
+    spgm_status: "route",
+    rio_required: true,
+    muss_required: true,
+    receipt_event_recommended: true,
+    receipt_decision_hint: "BLOCK",
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_authorize: false,
+      may_execute: false,
+      may_write_ledger: false,
+      may_create_memory: false,
+    },
+    required_action: "rio_review_required",
+    ...overrides,
+  };
+}
+
+describe("SPG-M Policy Review Preview", () => {
+  it("holds when intent is missing", () => {
+    const result = buildSpgmPolicyReviewPreview({ policy, policyReview: spgmReview() });
+
+    assert.equal(result.status, "hold");
+    assert.equal(result.mode, "non_executing");
+    assert.equal(result.error, "SPGM_POLICY_REVIEW_MISSING_INTENT");
+    assert.match(result.authority_boundary, /No action may proceed/);
+  });
+
+  it("returns non-executing policy preview without SPG-M metadata", () => {
+    const result = buildSpgmPolicyReviewPreview({
+      intent: { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+    });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.mode, "non_executing");
+    assert.equal(result.governance.governance_decision, "AUTO_APPROVE");
+    assert.equal(result.governance.requires_approval, false);
+    assert.equal(result.policy_effect.may_authorize, false);
+    assert.equal(result.policy_effect.may_execute, false);
+    assert.equal(result.policy_effect.may_write_ledger, false);
+  });
+
+  it("escalates preview to REQUIRE_HUMAN when SPG-M review requires RIO", () => {
+    const result = buildSpgmPolicyReviewPreview({
+      intent: { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      policyReview: spgmReview(),
+    });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.mode, "non_executing");
+    assert.equal(result.governance.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(result.governance.requires_approval, true);
+    assert.equal(result.governance.spgm_policy_context_status, "escalated_to_review");
+    assert.ok(result.governance.checks.some((check) => check.check === "spgm_policy_review_context"));
+  });
+
+  it("does not override AUTO_DENY", () => {
+    const result = buildSpgmPolicyReviewPreview({
+      intent: { action: "self_authorize", agent_id: "bondi", target_environment: "local", confidence: 100 },
+      policy,
+      policyReview: spgmReview(),
+    });
+
+    assert.equal(result.governance.governance_decision, "AUTO_DENY");
+    assert.equal(result.governance.status, "blocked");
+    assert.equal(result.governance.risk_tier, "CRITICAL");
+  });
+
+  it("rejects unsafe SPG-M review metadata without creating authority", () => {
+    const result = buildSpgmPolicyReviewPreview({
+      intent: { action: "read_email", agent_id: "bondi", target_environment: "local", confidence: 90 },
+      policy,
+      policyReview: spgmReview({
+        policy_effect: {
+          may_inform_policy_review: true,
+          may_authorize: true,
+          may_execute: false,
+          may_write_ledger: false,
+          may_create_memory: false,
+        },
+      }),
+    });
+
+    assert.equal(result.governance.governance_decision, "AUTO_APPROVE");
+    assert.equal(result.governance.spgm_policy_context_status, "rejected_or_contained");
+    assert.equal(result.policy_effect.may_authorize, false);
+    assert.equal(result.policy_effect.may_execute, false);
+  });
+});

--- a/gateway/tests/spgm-route.test.mjs
+++ b/gateway/tests/spgm-route.test.mjs
@@ -11,6 +11,71 @@ import spgmRoutes from "../routes/spgm.mjs";
 let server;
 let baseUrl;
 
+const previewPolicy = {
+  status: "active",
+  policy_version: "test-spgm-route-policy",
+  policy_hash: "test_spgm_route_policy_hash",
+  scope: {
+    agents: ["bondi"],
+    systems: ["local"],
+  },
+  action_classes: [
+    {
+      class_id: "read_operations",
+      pattern: "read_*",
+      governance_decision: "AUTO_APPROVE",
+      risk_tier: "LOW",
+    },
+    {
+      class_id: "blocked_operations",
+      pattern: "self_authorize|bypass_governance",
+      governance_decision: "AUTO_DENY",
+      risk_tier: "CRITICAL",
+      description: "Invariant violation.",
+    },
+  ],
+  risk_tiers: {
+    LOW: { severity: 1 },
+    MEDIUM: { severity: 2 },
+    HIGH: { severity: 3 },
+    CRITICAL: { severity: 4 },
+  },
+  approval_requirements: {
+    AUTO_APPROVE: { approvals_required: 0, required_roles: [] },
+    AUTO_DENY: { approvals_required: -1, required_roles: [] },
+    REQUIRE_HUMAN: { approvals_required: 1, required_roles: ["approver", "root_authority"] },
+  },
+  expiration_rules: {
+    LOW: null,
+    MEDIUM: 3600,
+    HIGH: 1800,
+    CRITICAL: 900,
+  },
+};
+
+function reviewMetadata(overrides = {}) {
+  return {
+    accepted: true,
+    context_type: "spgm_policy_review_metadata",
+    mode: "non_executing",
+    consequence_class: 3,
+    spgm_status: "route",
+    rio_required: true,
+    muss_required: true,
+    receipt_event_recommended: true,
+    receipt_decision_hint: "BLOCK",
+    policy_effect: {
+      may_inform_policy_review: true,
+      may_authorize: false,
+      may_execute: false,
+      may_write_ledger: false,
+      may_create_memory: false,
+    },
+    required_action: "rio_review_required",
+    ...overrides,
+  };
+}
+
 function buildTestApp() {
   const app = express();
   app.use(express.json());
@@ -71,6 +136,7 @@ describe("SPG-M Routes", () => {
     assert.equal(data.mode, "non_executing");
     assert.equal(data.capabilities.intake_validation, true);
     assert.equal(data.capabilities.receipt_handoff_metadata, true);
+    assert.equal(data.capabilities.policy_review_preview, true);
     assert.ok(data.not_capable_of.includes("execution"));
     assert.ok(data.not_capable_of.includes("ledger_write"));
     assert.match(data.authority_boundary, /cannot approve/);
@@ -134,6 +200,41 @@ describe("SPG-M Routes", () => {
     assert.equal(data.policy_review.required_action, "rio_review_required");
     assert.equal(data.policy_review.policy_effect.may_authorize, false);
     assert.match(data.authority_boundary, /does not approve/);
+  });
+
+  it("previews RIO policy review with SPG-M escalation", async () => {
+    const { status, data } = await post("/spgm/policy-review", {
+      intent: {
+        action: "read_email",
+        agent_id: "bondi",
+        target_environment: "local",
+        confidence: 90,
+      },
+      policy: previewPolicy,
+      policy_review: reviewMetadata(),
+    });
+
+    assert.equal(status, 200);
+    assert.equal(data.status, "ok");
+    assert.equal(data.mode, "non_executing");
+    assert.equal(data.review_type, "spgm_policy_review_preview");
+    assert.equal(data.governance.governance_decision, "REQUIRE_HUMAN");
+    assert.equal(data.governance.spgm_policy_context_status, "escalated_to_review");
+    assert.equal(data.policy_effect.may_authorize, false);
+    assert.equal(data.policy_effect.may_execute, false);
+    assert.equal(data.policy_effect.may_write_ledger, false);
+  });
+
+  it("holds SPG-M policy review preview without an intent", async () => {
+    const { status, data } = await post("/spgm/policy-review", {
+      policy: previewPolicy,
+      policy_review: reviewMetadata(),
+    });
+
+    assert.equal(status, 400);
+    assert.equal(data.status, "hold");
+    assert.equal(data.mode, "non_executing");
+    assert.equal(data.error, "SPGM_POLICY_REVIEW_MISSING_INTENT");
   });
 
   it("fails closed on invalid intake packets", async () => {


### PR DESCRIPTION
Adds a non-executing SPG-M policy review preview route, helper, tests, and examples.