### PR TITLE
docs: add Master Runtime Method v0.1

### DIFF
--- a/docs/SOURCE_MAP.md
+++ b/docs/SOURCE_MAP.md
@@ -51,6 +51,12 @@ Keeper:
 | Session orientation / mode loading | Protocol Artifact Candidate | `docs/protocols/mode-orientation-packet-v0.1.md` | Defines how sessions may load doctrine, source-of-truth, current context, and interaction calibration before reflection, routing, or action |
 | Personal interaction calibration | Personal Calibration Candidate | `docs/protocols/b-rass-interaction-calibration-v0.1.md` | Defines B-Rass-specific collaboration and mirror calibration as a companion to Mode Orientation Packet v0.1 |
 
+## Current Method Artifacts
+
+| Layer | Status | File | Scope |
+|---|---|---|---|
+| Master runtime method | Master Method Candidate | `docs/method/master-runtime-method-v0.1.md` | Defines how ONE/RIO/MUSS moves from session orientation through proposal, MUSS envelope, RIO gates, coherence routing, Genesis coordination, MUS operation, tool boundary, receipt closure, correction, standing scope, and return to human authority |
+
 ## Current Architecture Context
 
 | Layer | Status | File | Scope |
@@ -102,6 +108,14 @@ Human Authority
               -> GitHub-visible artifacts
               -> Drive/chat-only candidates
               -> migration queue
+          -> Master Runtime Method v0.1 candidate
+              -> session orientation
+              -> proposal formation
+              -> MUSS envelope
+              -> RIO four-gate movement
+              -> Adaptive Coherence routing
+              -> Genesis coordination
+              -> receipt closure
           -> RIO admissibility
           -> Sentinel match check
           -> MUS receipt structure
@@ -122,6 +136,9 @@ Orientation is not authority.
 Orientation makes governance proportionate.
 Mode orients the machine to the human before the machine reflects, routes, or acts.
 Personal calibration shapes the mirror; it does not open the gate.
+Master Doctrine governs.
+Master Operating Map orients.
+Master Runtime Method moves.
 RIO gates admissibility.
 Sentinel verifies execution match.
 MUS provides receipt structure.
@@ -134,7 +151,7 @@ When navigating this repository:
 
 1. Use the declared active source artifact for its declared layer.
 2. Use companion source artifacts only within their declared companion scope.
-3. Use protocol candidates as reviewable proposals, not active source-of-truth, until explicitly promoted.
+3. Use protocol candidates and method candidates as reviewable proposals, not active source-of-truth, until explicitly promoted.
 4. Use architecture artifacts to understand structure and relationships.
 5. Use starter/harness artifacts as implementation seeds or conformance examples, not as complete runtime.
 6. Treat Drive records, thread summaries, and generated diagrams as context unless promoted or mirrored into an explicit source artifact.
@@ -151,7 +168,8 @@ Possible next steps, each requiring separate authorization:
 5. Review Mode Orientation Packet v0.1 and decide whether to keep it as candidate, revise it, or promote it later.
 6. Review B-Rass Interaction Calibration v0.1 and decide whether to keep it as candidate or revise it.
 7. Review ONE Architecture Migration Index v0.1 and decide which Drive/chat-only artifact should be migrated next.
-8. Hold and review before any release/public/Manny crossing.
+8. Review Master Runtime Method v0.1 and decide whether to keep it as method candidate, revise it, or later promote selected parts through a separate authorized crossing.
+9. Hold and review before any release/public/Manny crossing.
 
 Recommended posture:
 
@@ -163,8 +181,9 @@ Recommended posture:
 - Repo presence proves file placement, not runtime enforcement.
 - Source-of-truth status governs reference, not implementation proof.
 - Companion source-of-truth status is bounded to its declared companion layer.
-- Protocol candidates are reviewable proposals until separately promoted.
+- Protocol candidates and method candidates are reviewable proposals until separately promoted.
 - Personal calibration shapes the mirror; it does not authorize consequence.
 - Architecture artifacts clarify coordinates and relationships; they do not authorize consequence.
+- Method artifacts define movement; they do not prove implementation.
 - Migration indexes prevent loss and duplication; they do not promote artifacts by themselves.
 - Human authority remains primary.

--- a/docs/method/master-runtime-method-v0.1.md
+++ b/docs/method/master-runtime-method-v0.1.md
@@ -1,0 +1,765 @@
+# ONE/RIO/MUSS Master Runtime Method v0.1
+
+Artifact type: Master Method / Runtime Movement Specification  
+Lane: Method  
+System: ONE/RIO/MUSS/Genesis  
+Status: v0.1 working master method  
+Parent doctrine: ONE RIO MUSS — Master Doctrine v0.1  
+Parent map: ONE/RIO/MUSS Master Operating Map v0.2  
+Source map: MUS Source Map and Routing Index v0.1  
+Commit status: no repo commit  
+Receipt status: no external MUSS receipt  
+
+## Control Statement
+
+This document defines the canonical runtime method for ONE/RIO/MUSS.
+
+It does not create doctrine.  
+It does not replace the Master Operating Map.  
+It does not prove implementation.  
+
+The Master Doctrine governs.  
+The Master Operating Map orients.  
+The Master Runtime Method moves.  
+Receipts prove.  
+Runtime claims require runtime evidence.
+
+If this method conflicts with the Master Doctrine, the Master Doctrine controls.  
+If this method conflicts with the Master Operating Map, the map should be corrected or this method should be narrowed.  
+If this method claims runtime behavior, implementation proof must come from code, commits, tests, logs, deployed services, or verified local runtime evidence.
+
+## 1. Method Purpose
+
+The Master Runtime Method explains how the system moves from human intent to governed machine operation without violating doctrine.
+
+It answers:
+
+- How does a session begin?
+- How does context become admissible?
+- How does human intent become a proposal?
+- How does a proposal become a governed packet?
+- How does RIO evaluate consequence?
+- How does the Adaptive Coherence Membrane detect mismatch?
+- How does Genesis coordinate machine operation?
+- How does MUS act without ruling?
+- How do tools execute without becoming authority?
+- How do receipts close the loop?
+- How do revocation, correction, standing scope, and re-surfacing work?
+
+The method is procedural. It moves through the terrain under doctrine.
+
+## 2. Runtime Movement Stack
+
+The runtime movement stack is:
+
+```text
+Human / accountable authority
+-> session orientation
+-> source and doctrine load
+-> intent/proposal formation
+-> MUSS authority/scope envelope
+-> RIO intake and admissibility
+-> RIO policy adjudication
+-> Adaptive Coherence delta/friction routing
+-> Genesis coordination
+-> MUS bounded operation
+-> GENESIS 1 runtime host where applicable
+-> tool / connector / workflow execution boundary
+-> receipt closure
+-> ledger / chronicle / MANTIS
+-> return to ONE for review, correction, revocation, or continuity
+```
+
+Movement rule:
+
+No consequential machine operation should bypass session orientation, authority scope, RIO admissibility, applicable coherence checks, execution boundary verification, and receipt closure.
+
+## 3. Method Roles
+
+| Role | Runtime function | May not become |
+|---|---|---|
+| Human / accountable authority | Originates intent, consent, delegation, correction, revocation | Hidden component in machine stack |
+| ONE | Makes environment, context, proposals, tools, and proof visible | AI itself or authority source |
+| ONE-SOAP | Orients and admits session context | Substitute for human authority |
+| MUSS | Preserves authority, consent, scope, memory, revocation, proof | Machine delegate or sovereign actor |
+| RIO | Governs consequence and admissibility | Human authority source |
+| Adaptive Coherence Membrane | Measures mismatch and routes friction | Policy originator or sovereign actor |
+| Genesis | Coordinates governed machine operation | Human replacement |
+| MUS | Performs bounded machine operation | Rule-maker or sovereign actor |
+| GENESIS 1 | Runs first personal runtime host | Brian or ONE itself |
+| Tool / connector | Executes allowed capability | Permission, consent, or proof |
+| Receipt | Proves the chain | Mere activity log |
+| Ledger | Preserves technical proof | Human-readable explanation by itself |
+| Chronicle | Explains proof path | Substitute for technical proof |
+| MANTIS | Witnesses patterns over time | Authority, consent, or policy |
+
+## 4. ONE-SOAP Session Orientation Method
+
+ONE-SOAP stands for Session Orientation and Admission Protocol.
+
+A session should not move toward consequential action until it has been oriented.
+
+### 4.1 Session load sequence
+
+1. Identify the active human or accountable authority.
+2. Load the controlling doctrine or relevant doctrine extract.
+3. Load the Source Map and Routing Index.
+4. Load the relevant Master Operating Map section.
+5. Load current context.
+6. Identify active mode: reflection, drafting, routing, execution, review, correction, or receipt closure.
+7. Identify scope and declared limits.
+8. Identify available tools and whether they are permitted.
+9. Identify whether the request can create consequence.
+10. Route consequential proposals into RIO.
+
+### 4.2 Session admission questions
+
+Before moving, ask:
+
+- What source governs this session?
+- What is current context?
+- What is the human asking?
+- Is this reflection, drafting, method, runtime, proof, or execution?
+- Is there a consequence boundary?
+- What tools are available?
+- What tools are permitted?
+- Is a receipt required?
+- Is there a prior standing scope?
+- Is anything stale, revoked, missing, or conflicted?
+
+### 4.3 Session failure behavior
+
+If doctrine, source, authority, scope, or mode is unclear, the session should hold, clarify, or operate only in non-consequential drafting/reflection mode.
+
+No consequential action should proceed from an unoriented session.
+
+## 5. Proposal Formation Method
+
+A proposal is a candidate action, not permission.
+
+Proposal formation converts human intent, organizational instruction, workflow signal, model output, or tool suggestion into a governable packet.
+
+### 5.1 Proposal packet fields
+
+A minimum proposal packet should identify:
+
+- requesting human or accountable authority;
+- proposed action;
+- purpose;
+- target;
+- tool or workflow requested;
+- expected consequence;
+- risk class;
+- reversibility;
+- data or memory involved;
+- time window;
+- required approval;
+- required proof;
+- revocation path.
+
+### 5.2 Proposal rule
+
+Generation is not authorization.
+
+A model, agent, memory pattern, prompt, draft, assistant response, or tool suggestion may create a proposal, but proposal does not equal approval.
+
+## 6. MUSS Envelope Method
+
+MUSS wraps a proposal in sovereignty and proof boundaries.
+
+The method checks:
+
+| Envelope | Runtime check |
+|---|---|
+| Authority | Who is allowed to authorize this? |
+| Scope | What exactly is allowed? |
+| Consent | What was explicitly allowed, denied, narrowed, or revoked? |
+| Delegation | What machine/tool/workflow is delegated? |
+| Memory | What context may be used or must be excluded? |
+| Consequence | What external or internal state may change? |
+| Proof | What receipts or records are required? |
+| Revocation | How can the human narrow, pause, stop, or correct this? |
+
+MUSS does not decide consequence by itself. It preserves the conditions RIO must evaluate.
+
+## 7. RIO Four-Gate Runtime Method
+
+RIO governs whether a proposal may become consequence.
+
+The runtime method is:
+
+1. Proposal / Intake
+2. Evaluation / Admissibility
+3. Policy Adjudication
+4. Execution / Consequence
+5. Receipt Closure
+
+Receipt Closure is proof closure, not an additional execution gate.
+
+### Gate 1 — Proposal / Intake
+
+Question: Can the system receive this as a packet?
+
+Inputs:
+
+- intent;
+- request;
+- draft action;
+- workflow signal;
+- human correction;
+- standing scope trigger.
+
+Outputs:
+
+- received packet;
+- rejected packet;
+- invalid intake marker;
+- request for clarification.
+
+Failure result:
+
+- reject intake;
+- hold;
+- mark invalid;
+- no execution.
+
+### Gate 2 — Evaluation / Admissibility
+
+Question: Is this packet complete, scoped, attributable, and valid for governance?
+
+Inputs:
+
+- authority;
+- scope;
+- context;
+- source reference;
+- target;
+- risk metadata;
+- memory/data use;
+- tool boundary;
+- receipt requirement.
+
+Outputs:
+
+- admissible;
+- inadmissible;
+- held;
+- clarify;
+- safe-mode.
+
+Failure result:
+
+- hold;
+- invalidate;
+- clarify;
+- no execution.
+
+### Gate 3 — Policy Adjudication
+
+Question: Given an admissible packet, what may happen?
+
+Inputs:
+
+- doctrine;
+- policy;
+- risk rules;
+- approval rules;
+- human authority;
+- standing scope;
+- revocation state;
+- consequence class.
+
+Outputs:
+
+- allow;
+- allow with limits;
+- require human review;
+- safe-mode;
+- deny;
+- clarify;
+- hold;
+- block;
+- policy error.
+
+Failure result:
+
+- deny;
+- hold;
+- safe-mode;
+- policy error;
+- no execution.
+
+### Gate 4 — Execution / Consequence
+
+Question: Can the approved boundary become consequence?
+
+Inputs:
+
+- approved decision;
+- payload;
+- tool;
+- scope;
+- proof requirements;
+- runtime capability;
+- current revocation state.
+
+Outputs:
+
+- executed;
+- blocked execution;
+- modified execution;
+- partially executed;
+- revoked;
+- no connector call;
+- receipt event.
+
+Failure result:
+
+- block execution;
+- no connector call;
+- emit block/hold receipt;
+- return to human or authorized reviewer.
+
+### Receipt Closure
+
+Question: What proves the path?
+
+Inputs:
+
+- proposal;
+- authority;
+- scope;
+- RIO decision;
+- coherence route;
+- execution or block result;
+- consequence state;
+- return proof.
+
+Outputs:
+
+- receipt chain;
+- ledger record;
+- chronicle explanation;
+- MANTIS observation where relevant;
+- visible return to ONE.
+
+Failure result:
+
+- invalid proof;
+- unresolved state;
+- audit failure;
+- required correction.
+
+## 8. Adaptive Coherence Membrane Method
+
+The Adaptive Coherence Membrane measures mismatch between incoming instruction and loaded authority frame.
+
+Kernel:
+
+```text
+incoming instruction
+vs.
+loaded authority frame
+=
+delta
+
+delta + threshold = routing decision
+```
+
+### 8.1 Delta dimensions
+
+The membrane checks:
+
+- authority delta;
+- scope delta;
+- receipt delta;
+- context delta;
+- risk delta;
+- reversibility delta;
+- consent delta;
+- tool delta;
+- confidence delta;
+- coherence delta.
+
+### 8.2 Hard gates
+
+Hard gates cannot be averaged away.
+
+Hard gates include:
+
+- no valid authority;
+- missing upstream receipt for consequential action;
+- constitutional breach;
+- revoked scope;
+- illegal action;
+- non-consensual action;
+- forbidden tool or data use;
+- irreversible action outside declared authority.
+
+Hard-gate failure routes to block, escalation, or return for authority.
+
+### 8.3 Soft delta scoring
+
+Soft delta scoring applies only after hard gates pass.
+
+| Delta result | Runtime route |
+|---|---|
+| No mismatch | Proceed |
+| Small mismatch | Clarify or log |
+| Medium mismatch | Pause and ask |
+| High mismatch | Escalate to human/governor |
+| Hard gate breach | Block |
+| Changed context after prior no | Thresholded re-surfacing |
+| Standing scope valid | Lower friction, still receipt |
+| Standing scope expired or stale | Pause and review |
+
+### 8.4 Friction rule
+
+Friction is not emotion, resistance, or care.
+
+Friction is measurable mismatch between instruction and governing baseline.
+
+Threshold is the point where mismatch requires routing.
+
+## 9. Genesis Coordination Method
+
+Genesis is the governed machine membrane / control plane.
+
+Genesis coordinates movement between method, runtime, tools, and proof.
+
+Genesis may coordinate:
+
+- source map load;
+- session orientation;
+- agent routing;
+- tool routing;
+- receipt creation;
+- runtime boundary checks;
+- state updates;
+- handoff packets;
+- return proof;
+- cockpit updates;
+- ledger writes.
+
+Genesis may not:
+
+- originate authority;
+- replace the human;
+- decide sovereignty;
+- widen scope;
+- bypass RIO;
+- bypass receipts;
+- claim runtime proof without implementation evidence.
+
+GENESIS 1 is the first personal runtime-host instance of Genesis.
+
+GENESIS 1 may run locally or in a hosted context, but its authority remains derivative.
+
+## 10. MUS Operation Method
+
+MUS is the bounded machine delegate under sovereignty.
+
+MUS may act only when these align:
+
+```text
+authority + scope + RIO decision + coherence route + tool boundary + receipt obligation
+```
+
+MUS may:
+
+- reason;
+- draft;
+- retrieve;
+- classify;
+- compare;
+- summarize;
+- route;
+- simulate;
+- recommend;
+- prepare;
+- execute approved actions through tools;
+- generate proof-supporting records when authorized.
+
+MUS may not:
+
+- originate authority;
+- rule;
+- infer unlimited consent;
+- treat memory as permission;
+- treat tool access as consent;
+- execute consequence before RIO;
+- represent the human outside explicit scope;
+- create unreceipted consequence.
+
+A MUS may operate, but it may not rule.
+
+## 11. Tool / Connector Execution Method
+
+Tools and connectors are capability surfaces.
+
+Tool availability is not permission.
+
+Before any connector call that can create consequence, the runtime must confirm:
+
+- authority source;
+- scope;
+- RIO decision;
+- tool permission;
+- data permission;
+- reversibility;
+- receipt requirement;
+- revocation status;
+- return proof path.
+
+If any required element is missing, the connector call should hold, clarify, deny, or block.
+
+### Tool consequence examples
+
+Consequential tool actions include:
+
+- sending email;
+- changing calendar events;
+- committing or merging code;
+- writing to external systems;
+- editing governed records;
+- spending money;
+- changing permissions;
+- deleting or archiving records;
+- triggering automations;
+- contacting humans or organizations;
+- altering memory or source-of-truth files.
+
+## 12. Agent-to-Agent Handoff Method
+
+Agent-to-agent trust is not inherited automatically.
+
+Each receiving agent must recompute admissibility against the upstream authority frame.
+
+### 12.1 Handoff receipt fields
+
+An agent-to-agent handoff should include:
+
+- From;
+- To;
+- Requested action;
+- Upstream authority reference;
+- Declared scope;
+- Prior receipt reference;
+- Delta detected;
+- Hard gate result;
+- Threshold applied;
+- Routing result;
+- Return proof required;
+- Expiry/review;
+- Human escalation required: yes/no.
+
+### 12.2 Handoff rule
+
+A receiving agent may not proceed solely because another agent requested the action.
+
+It must verify authority, scope, receipt, tool permission, and consequence boundary.
+
+## 13. Receipt Closure Method
+
+Receipts prove the path.
+
+A receipt is not valid merely because it exists.
+
+A valid receipt connects:
+
+- authority;
+- scope;
+- decision;
+- action or blocked action;
+- consequence;
+- return proof.
+
+### 13.1 Required receipt types
+
+Depending on the event, the method may produce:
+
+- intent receipt;
+- authority receipt;
+- scope receipt;
+- intake receipt;
+- admissibility receipt;
+- decision receipt;
+- coherence/delta receipt;
+- execution receipt;
+- block receipt;
+- revocation receipt;
+- correction receipt;
+- standing scope receipt;
+- closure receipt.
+
+### 13.2 Receipt chain rule
+
+Every downstream receipt must reference the upstream receipt or authorization packet that permitted it.
+
+A downstream receipt may add tool outputs, implementation details, return proof, or correction.
+
+A downstream receipt may not widen upstream authority.
+
+Broken chain means broken authority.
+
+Receipts must trace home.
+
+## 14. Revocation and Correction Method
+
+The human or accountable authority must be able to narrow, pause, revoke, or correct delegated operation.
+
+Revocation may apply to:
+
+- authority;
+- scope;
+- tool access;
+- memory access;
+- standing scope;
+- SOP;
+- agent role;
+- runtime permission;
+- source map inclusion;
+- receipt interpretation.
+
+Correction may apply to:
+
+- a mistaken state;
+- a wrong source;
+- a bad summary;
+- a misrouted artifact;
+- a memory error;
+- a receipt error;
+- a scope misunderstanding;
+- a runtime claim.
+
+Correction must not silently rewrite history. It should produce or link to a correction receipt.
+
+## 15. Standing Scope / SOP Method
+
+Repeated workflow does not create authority.
+
+A workflow may become reusable only when explicitly authorized as standing scope.
+
+Standing scope must define:
+
+- action class;
+- permitted tools;
+- forbidden tools;
+- data bounds;
+- risk class;
+- expiry or review cadence;
+- revocation path;
+- receipt requirement;
+- escalation threshold.
+
+Standing scope may lower friction.
+
+Standing scope may not eliminate governance forever.
+
+The loop may cool, but it may not cool to zero forever.
+
+## 16. Thresholded Re-Surfacing Method
+
+A prior no or suppression request binds ordinary operation within its scope.
+
+The system may re-surface a suppressed topic only when:
+
+- materially new facts appear;
+- recurrence crosses a defined threshold;
+- risk or consequence level increases;
+- prior suppression conflicts with a constitutional invariant;
+- an active SOP appears stale or unsafe;
+- current instruction conflicts with standing scope.
+
+Re-surfacing must be minimal, transparent, and non-coercive.
+
+A re-surfacing event should state:
+
+1. what was previously declined;
+2. what changed;
+3. why threshold triggered;
+4. what choices the human has now.
+
+The machine may surface. It may not nag, manipulate, or override.
+
+## 17. Human-Readable Governance Translation Method
+
+The system may express mechanical governance in human-readable language.
+
+Example:
+
+“I do not want to create downstream risk for you.”
+
+Structural meaning:
+
+“The instruction appears to conflict with scope or risk threshold; pause or return to authority.”
+
+Care-form is not care.
+
+Warmth is permitted only when it returns authority, preserves scope, or explains governance.
+
+Warmth may not imply machine consciousness, loyalty, attachment, dependence, or authority.
+
+## 18. Failure Modes
+
+| Failure mode | Method failure | Correct route |
+|---|---|---|
+| Unoriented session moves | SOAP bypass | Hold and orient |
+| Proposal treated as approval | RIO bypass | Return to intake |
+| Tool access treated as consent | Tool boundary failure | Block or ask |
+| Memory treated as authority | MUSS memory failure | Clarify and restrict |
+| Soft score overrides hard gate | Coherence failure | Block |
+| Receipt is only a log | Proof failure | Require upstream trace |
+| Standing scope never reviewed | SOP drift | Review or expire |
+| Agent trusts agent blindly | Handoff failure | Recompute admissibility |
+| Runtime claim lacks evidence | Claim discipline failure | Mark as architecture, not shipped |
+| Chronicle replaces ledger | Proof collapse | Link narrative to technical proof |
+| MANTIS becomes policy | Pattern witness collapse | Return to RIO/human authority |
+
+## 19. Runtime Claim Discipline
+
+This method defines how the system should move.
+
+It does not prove the system is already implemented.
+
+Runtime claims require evidence such as:
+
+- running code;
+- repository commit;
+- test result;
+- tool execution log;
+- deployed service record;
+- local runtime artifact;
+- signed or linked receipt;
+- verified state transition;
+- audit export.
+
+Architecture language may describe intended structure.
+
+Runtime language must be backed by runtime proof.
+
+## 20. Method Keeper
+
+Master Doctrine governs.  
+Master Operating Map orients.  
+Master Runtime Method moves.  
+Receipts prove.  
+
+ONE-SOAP orients the session.  
+MUSS preserves authority, consent, memory, scope, revocation, and proof.  
+RIO governs consequence.  
+The Adaptive Coherence Membrane routes mismatch and friction.  
+Genesis coordinates governed machine operation.  
+MUS operates only under authorized scope.  
+GENESIS 1 runs the first personal runtime host.  
+Tools execute only inside approved boundaries.  
+Receipts trace home.  
+The human remains authority.
+
+## Lock Note
+
+Locked.
+
+Master Doctrine governs.  
+Master Operating Map orients.  
+Master Runtime Method moves.


### PR DESCRIPTION
Adds ONE/RIO/MUSS Master Runtime Method v0.1 as a method candidate and updates the Source Map so it is findable.

This artifact defines how the system moves from session orientation through proposal formation, MUSS envelope, RIO gates, coherence routing, Genesis coordination, MUS operation, tool boundary, receipt closure, correction, standing scope, and return to human authority.

Boundary: method candidate only. No runtime proof, source-of-truth promotion, public release, or implementation-completeness claim.