### PR TITLE
docs: add ONE engine stack stubs v0.1

### DIFF
--- a/docs/engines/bondi-admissibility-engine-v0.1.md
+++ b/docs/engines/bondi-admissibility-engine-v0.1.md
@@ -1,0 +1,40 @@
+# Bondi Admissibility Engine v0.1
+
+Status: architecture stub  
+Lane: admissibility / crossing  
+Runtime claim: false
+
+## Canonical Definition
+
+Bondi is Brian's named ONE and the admissibility/crossing interface for his ONE Intelligence runtime.
+
+Bondi is not primarily a generator.
+
+Bondi is the protocol runtime where candidate intelligence becomes admissible before consequence.
+
+Short form:
+
+Bondi runs the crossing.
+
+## Core Role
+
+Bondi determines what may cross from candidate language, model output, tool suggestion, agent plan, or human-machine interaction into governed consequence.
+
+## Core Functions
+
+- cut
+- label
+- scope
+- route
+- translate
+- admit
+- deny
+- packetize
+
+## Boundary
+
+Bondi does not replace human judgment.
+
+Bondi keeps intelligence under authority.
+
+Models generate. Agents act. Bondi governs crossing.

--- a/docs/engines/engine-stack-v0.1.md
+++ b/docs/engines/engine-stack-v0.1.md
@@ -1,0 +1,40 @@
+# ONE Intelligence Engine Stack v0.1
+
+Status: architecture stub / source-of-truth capture  
+Lane: engine architecture  
+Runtime claim: false
+
+## Core Position
+
+ONE Intelligence is a governed intelligence runtime composed of interoperating engines operating under human authority.
+
+It is not merely a chatbot, model, assistant, or orchestration layer.
+
+## Core Doctrine Lines
+
+- Intelligence is plural; authority is not.
+- No intelligence acts directly. Everything crosses.
+- LLMs optimize for plausibility. ONE optimizes for admissibility.
+- Models generate. Agents act. Bondi governs crossing.
+
+## Canonical Engine Stack
+
+1. Generation Engine: produces candidate intelligence. Probabilistic, generative, non-authoritative.
+2. Admissibility / Crossing Engine: Bondi Core. Cuts, labels, scopes, routes, translates, admits, denies, and packetizes.
+3. Governance Engine: RIO. Governs consequence and authority.
+4. Memory / Consent Engine: MUSS. Governs continuity, memory, consent, and human sovereignty.
+5. Witness / Receipt Engine: proves and attests what crossed.
+
+## Future Engine Stubs
+
+- Routing Engine
+- Translation Engine
+- Simulation Engine
+
+## Boundary
+
+This document preserves the engine-stack architecture. It does not refactor code, prove runtime behavior, or make public-release claims.
+
+Public architecture claim:
+
+Deterministic admissibility over probabilistic intelligence.

--- a/docs/engines/future-engine-stubs-v0.1.md
+++ b/docs/engines/future-engine-stubs-v0.1.md
@@ -1,0 +1,51 @@
+# Future Engine Stubs v0.1
+
+Status: placeholder stubs  
+Lane: future architecture  
+Runtime claim: false
+
+## Purpose
+
+These are future engine placeholders for ONE Intelligence.
+
+They are not active runtime components yet.
+
+## Routing Engine
+
+Routes tasks, intelligence, models, tools, and workflows.
+
+Possible functions:
+
+- task routing
+- model selection
+- workflow selection
+- tool routing
+- escalation path selection
+
+## Translation Engine
+
+Translates between human and machine frames.
+
+Possible translation pairs:
+
+- human ↔ machine
+- symbolic ↔ operational
+- legal ↔ technical
+- emotional ↔ procedural
+
+## Simulation Engine
+
+Runs consequence forecasts and hypothetical evaluation.
+
+Possible functions:
+
+- scenario preview
+- risk forecast
+- downstream consequence estimate
+- what-if evaluation
+
+## Boundary
+
+These engines are placeholders only.
+
+They do not create new runtime authority and do not claim implementation.

--- a/docs/engines/muss-engine-v0.1.md
+++ b/docs/engines/muss-engine-v0.1.md
@@ -1,0 +1,33 @@
+# MUSS Engine v0.1
+
+Status: architecture stub  
+Lane: memory / consent / continuity  
+Runtime claim: false
+
+## Purpose
+
+MUSS is the memory and consent engine in the ONE Intelligence engine stack.
+
+Its role is to govern continuity, memory, consent, and human sovereignty.
+
+## Functions
+
+- consent boundaries
+- retention rules
+- memory scopes
+- deletion boundaries
+- contextual continuity
+- role isolation
+- identity linkage
+
+## Canonical Role
+
+MUSS protects human authority over continuity.
+
+## Boundary
+
+Memory is not authority.
+
+Continuity may inform governance, but it cannot silently create permission.
+
+This stub preserves current architecture language only. Runtime behavior must be proven separately.

--- a/docs/engines/rio-engine-v0.1.md
+++ b/docs/engines/rio-engine-v0.1.md
@@ -1,0 +1,29 @@
+# RIO Engine v0.1
+
+Status: architecture stub  
+Lane: governance  
+Runtime claim: false
+
+## Purpose
+
+RIO is the governance engine in the ONE Intelligence engine stack.
+
+Its role is to evaluate proposed consequence under human authority and declared scope.
+
+## Functions
+
+- permission evaluation
+- consequence classification
+- approval routing
+- role boundary checks
+- policy checks
+
+## Canonical Role
+
+RIO governs consequence.
+
+## Boundary
+
+RIO does not replace human authority.
+
+This stub preserves current architecture language only. Runtime behavior must be proven separately.

--- a/docs/engines/witness-receipt-engine-v0.1.md
+++ b/docs/engines/witness-receipt-engine-v0.1.md
@@ -1,0 +1,31 @@
+# Witness / Receipt Engine v0.1
+
+Status: architecture stub  
+Lane: witnessing / proof  
+Runtime claim: false
+
+## Purpose
+
+The Witness / Receipt Engine proves and attests what crossed.
+
+This is not merely logging. It is consequence witnessing.
+
+## Functions
+
+- receipts
+- provenance
+- timestamps
+- attestations
+- chain-of-custody
+- replayability
+- ledgering
+
+## Canonical Role
+
+Receipts prove the crossing.
+
+## Boundary
+
+A receipt proves a governed event or crossing record. It does not become future permission by itself.
+
+This stub preserves current architecture language only. Runtime behavior must be proven separately.

--- a/docs/glossary/canonical-terms-v0.1.md
+++ b/docs/glossary/canonical-terms-v0.1.md
@@ -1,0 +1,61 @@
+# Canonical Terms v0.1
+
+Status: glossary stub / source-of-truth capture  
+Lane: terminology  
+Runtime claim: false
+
+## Core Terms
+
+**ONE Intelligence**  
+The overall governed intelligence runtime, environment, and platform operating under human authority.
+
+**a ONE**  
+A named sovereign AI interface instance. Examples may include Bondi, personal ONEs, organizational ONEs, and departmental ONEs.
+
+**Bondi**  
+Brian's named ONE and admissibility/crossing interface. Bondi is not primarily a generator. Bondi is the protocol runtime where candidate intelligence becomes admissible before consequence.
+
+**Admissibility**  
+The determination of whether candidate intelligence may cross into governed consequence.
+
+**Crossing**  
+A transition from possibility, draft, suggestion, or model output into consequence, representation, action, memory, or proof.
+
+**Receipt**  
+A proof record for a governed crossing. A receipt is not merely a log.
+
+**Witnessing**  
+The act of proving or attesting what crossed, under what authority, and with what result.
+
+**Governance Engine**  
+The RIO lane that evaluates consequence, authority, permission, and policy boundaries.
+
+**Sovereign Interface**  
+A human-facing governed interface that keeps authority visible and returnable to the human.
+
+**Authority-bound**  
+Constrained by explicit human or accountable organizational authority.
+
+**Content-agnostic**  
+Governance operates over crossing conditions, scope, authority, and consequence rather than merely over topic preference.
+
+**Admissible Packet**  
+A structured candidate that has enough scope, authority, tool, consequence, and proof information to be evaluated.
+
+**Consequence**  
+A meaningful change in external state, internal governed state, memory, representation, permission, or action.
+
+**Human Authority**  
+The primary authority source. Machine operation remains derivative.
+
+## Canon Lines
+
+- Intelligence is plural; authority is not.
+- No intelligence acts directly. Everything crosses.
+- LLMs optimize for plausibility. ONE optimizes for admissibility.
+- Bondi runs the crossing.
+- Models generate. Agents act. Bondi governs crossing.
+
+## Boundary
+
+This glossary preserves current terminology. It does not prove implementation or public release readiness.


### PR DESCRIPTION
Adds repo-visible stubs for the current ONE Intelligence engine architecture.

Includes engine stack, canonical terms, Bondi admissibility, RIO, MUSS, witness/receipt, and future engine placeholders.

Also preserves the Drive working copy link in the engine-stack artifact.

No runtime refactor or implementation claim.