### PR TITLE
docs: add architecture notes

### DIFF
--- a/docs/architecture/constitutional-grammar-plane-v0.1.md
+++ b/docs/architecture/constitutional-grammar-plane-v0.1.md
@@ -1,0 +1,68 @@
+# Constitutional Grammar Plane v0.1
+
+Status: architecture stub / doctrine candidate  
+Lane: language governance before action governance  
+Runtime claim: false
+
+## Purpose
+
+This file preserves the grammar-before-action layer.
+
+Core claim:
+
+Bondi / Scribe governs language formation before action governance begins.
+
+RIO governs consequence after human commit.
+
+MANTIS witnesses pattern and context but does not become authority.
+
+## Canon Lines
+
+Govern language before governing action.
+
+Bondi governs the grammar of intent. RIO governs the consequence of action. MANTIS witnesses the pattern. The human remains the authority.
+
+Grammar is upstream. Governance is downstream. Authority stays human.
+
+## Flow
+
+Human signal  
+→ Bondi / Scribe  
+→ Constitutional Grammar Plane  
+→ Context Mapper / Field-Aware Mapping  
+→ Proposal Packet  
+→ Human Commit  
+→ RIO  
+→ Sentinel  
+→ MUS Receipt  
+→ Ledger / Chronicle  
+→ MANTIS witness feedback
+
+## Layer Boundaries
+
+The Constitutional Grammar Plane may structure, clarify, map, flag, and contextualize intent.
+
+It may not approve, deny, create consent, or become authority.
+
+MANTIS is a witness-signal contributor inside the broader Constitutional Context Engine.
+
+MANTIS is not the whole Constitutional Context Engine.
+
+## Receipt Rule
+
+Grammar receipts prove interpretation.
+
+MUS receipts prove governed consequence.
+
+## Failure Modes
+
+- Grammar-to-action collapse
+- Corpus authority leak
+- Witness-as-judge collapse
+
+## Keeper
+
+Bondi / Scribe = grammar before action.  
+RIO / Sentinel = consequence after commit.  
+MANTIS = witness, not judge.  
+MUS / Ledger = proof, not permission.

--- a/docs/glossary/constitutional-grammar-terms-v0.1.md
+++ b/docs/glossary/constitutional-grammar-terms-v0.1.md
@@ -1,0 +1,47 @@
+# Constitutional Grammar Terms v0.1
+
+Status: glossary stub / doctrine candidate companion  
+Lane: language governance before action governance  
+Runtime claim: false
+
+## Terms
+
+**Constitutional Grammar Plane**  
+The layer where human signal is structured, clarified, mapped, and prepared before action governance begins.
+
+**Language Constitution**  
+The rules that shape how language may become a proposal without becoming authority or action by itself.
+
+**Context Mapper**  
+A mapping function that locates language within relevant context before action governance.
+
+**Field-Aware Mapping**  
+Contextual mapping that considers surrounding pattern, role, source, scope, and consequence field.
+
+**MANTIS Witness Signals**  
+Observed recurrence, drift, pattern, or context signals contributed by MANTIS. These signals inform review but do not authorize.
+
+**Proposal Packet**  
+A structured packet that carries interpreted intent toward human commit and RIO review.
+
+**Grammar Receipt**  
+A receipt that proves interpretation, mapping, or packetization. It does not prove governed consequence.
+
+**Witness Receipt**  
+A receipt that records a witnessed pattern, context signal, or observation. It does not authorize action.
+
+**Human Commit**  
+The human act that moves structured language toward action governance.
+
+**Grammar-to-action collapse**  
+A failure mode where structured language is treated as action approval.
+
+**Corpus authority leak**  
+A failure mode where training data, memory, or context pattern is treated as authority.
+
+**Witness-as-judge collapse**  
+A failure mode where MANTIS observation is treated as judgment, authorization, or execution permission.
+
+## Boundary
+
+These terms preserve the grammar-before-action layer. They do not create runtime behavior or source-of-truth promotion by themselves.


### PR DESCRIPTION
Adds two architecture notes.

No code changes.