### PR TITLE
docs: add C2C-001 concordance control registry target spec

### DIFF
--- a/config/concordance_matrix.sample.json
+++ b/config/concordance_matrix.sample.json
@@ -1,0 +1,79 @@
+[
+  {
+    "primitive_id": "P-CONV-001",
+    "primitive_name": "Triadic Convergence Check",
+    "aliases": [
+      "Triadic Convergence Gate",
+      "Threefold Continuity Check",
+      "Constraint-Driven Convergence"
+    ],
+    "active_office": "validation_methodology",
+    "office_function": "Checks whether authority, meaning, and execution remain aligned; broken convergence triggers HOLD.",
+    "allowed_actions": [
+      "classify_convergence_state",
+      "surface_failed_pin",
+      "recommend_hold"
+    ],
+    "prohibited_actions": [
+      "authorize_action",
+      "issue_execution_token",
+      "override_rio",
+      "override_sentinel",
+      "treat_model_agreement_as_permission"
+    ],
+    "required_authority_level": "none_observational",
+    "consequence_classes": [
+      "private_reflection",
+      "internal_architecture",
+      "repo_documentation"
+    ],
+    "required_receipt_type": "hold_receipt",
+    "inversion_or_sibling": "RIO admissibility gate; Sentinel fidelity gate; human authority event",
+    "failure_mode": "authority_substitution",
+    "repair_path": "ROUTE_TO_CONCORDANCE_REVIEW",
+    "evidence_level": "TARGET_STATE_SPEC",
+    "status": "DO_NOT_CANONIZE_AS_GATE",
+    "source_anchor": "00_PATTERN_CONCORDANCE — Name Office Function Map v0.1",
+    "notes": "Convergence is signal, not permission. Broken convergence can require HOLD; convergence cannot authorize movement."
+  },
+  {
+    "primitive_id": "P-GRAMMAR-001",
+    "primitive_name": "Grammar / Translation Office",
+    "aliases": [
+      "Bondi",
+      "Scribe",
+      "Translator",
+      "Pattern Router"
+    ],
+    "active_office": "formation_layer",
+    "office_function": "Structures human signal into candidate packets and detects register/category errors.",
+    "allowed_actions": [
+      "mirror_intent",
+      "structure_packet",
+      "classify_register",
+      "surface_uncertainty",
+      "route_for_review"
+    ],
+    "prohibited_actions": [
+      "authorize_action",
+      "self_certify_output",
+      "issue_receipt",
+      "claim_runtime_proof",
+      "publish_without_approval"
+    ],
+    "required_authority_level": "policy_profile",
+    "consequence_classes": [
+      "private_reflection",
+      "internal_architecture",
+      "repo_documentation"
+    ],
+    "required_receipt_type": "classification_receipt",
+    "inversion_or_sibling": "Witness office; MUS receipt layer; Human SourcePoint",
+    "failure_mode": "witness_authorizer_collapse",
+    "repair_path": "HOLD_AND_RETURN",
+    "evidence_level": "TARGET_STATE_SPEC",
+    "status": "PENDING_REVIEW",
+    "source_anchor": "C2C-001 Concordance Control Registry v0.1",
+    "notes": "Grammar may form. Grammar may not authorize."
+  }
+]

--- a/docs/c2c/c2c-001-concordance-control-registry-v0.1.md
+++ b/docs/c2c/c2c-001-concordance-control-registry-v0.1.md
@@ -1,0 +1,170 @@
+---
+id: C2C-001
+title: Concordance Control Registry
+version: v0.1
+status: TARGET_STATE_SPEC
+register: repo-safe architecture / target-state implementation blueprint
+runtime_status: not_implemented_by_this_file
+claim_level: target-state specification
+authority: Brian Kent Rasmussen / human SourcePoint
+---
+
+# C2C-001 — Concordance Control Registry v0.1
+
+## Purpose
+
+C2C-001 defines how ONE/RIO/MUSS architectural offices become machine-readable governance boundaries.
+
+It exists to prevent role collapse, office overreach, primitive inversion, and vocabulary drift before implementation.
+
+This document does not claim the control is currently installed, audited, certified, or runtime-enforced. It names the lock the system is designed to install.
+
+## Register Seal
+
+This document describes the intended architecture and target governance posture of the Concordance Control Registry.
+
+Implementation status must be verified separately through repository evidence, tests, receipts, runtime logs, and human ratification.
+
+## Problem
+
+ONE/RIO/MUSS uses recurring patterns across many offices. The same geometry can appear as source law, formation grammar, admissibility review, execution boundary, witness layer, receipt return, learning loop, or public-safe explanation.
+
+Pattern sameness is not office sameness.
+
+Without a concordance, a model or implementer can recognize the repeated pattern and accidentally collapse the office distinction that gives the architecture its safety.
+
+## Core Rule
+
+Every runtime actor must be bound to a declared office.
+
+Every office must define:
+
+- what it is;
+- what it may do;
+- what it must not do;
+- what authority it requires;
+- what receipt it returns;
+- what sibling or inversion it must not collapse into;
+- what failure mode is triggered if it overreaches.
+
+## Conversion Chain
+
+```text
+Doctrine
+→ Concordance
+→ Schema
+→ Validator
+→ Gate / HOLD
+→ Receipt
+```
+
+Hybrid expression:
+
+```text
+Meaning
+→ Office
+→ Boundary
+→ Check
+→ Crossing
+→ Return
+```
+
+## Office Integrity Invariants
+
+A conforming implementation must preserve these invariants:
+
+```text
+A model cannot become an executor.
+A witness cannot become an authorizer.
+A receipt cannot become permission.
+A pattern cannot become proof.
+A tool cannot become sovereign.
+A convergence signal cannot become authority.
+```
+
+## Concordance Entry Fields
+
+Each concordance entry should include:
+
+| Field | Meaning |
+|---|---|
+| primitive_id | Stable identifier for the locked primitive |
+| primitive_name | Canonical or currently preferred primitive name |
+| aliases | Prior names, candidate names, local names, or private-register names |
+| active_office | Office or role currently wearing the pattern |
+| office_function | What the pattern does in this office |
+| allowed_actions | Actions this office may perform |
+| prohibited_actions | Actions this office must never perform |
+| required_authority_level | Human authority, policy, or envelope required |
+| consequence_classes | Consequence classes where this office may operate |
+| required_receipt_type | Receipt required if the office acts or refuses |
+| inversion_or_sibling | Related office that must not be collapsed into this one |
+| failure_mode | What breaks if this office overreaches |
+| repair_path | What the system does on failure |
+| evidence_level | DRIVE_VERIFIED, THREAD_SUPPORTED, PENDING_DOC_READ, etc. |
+| status | LOCKED_COMPONENT, TARGET_STATE_SPEC, HOLD_AS_ALIAS, MERGE_ALIAS, etc. |
+| source_anchor | Source doc, repo file, registry row, or receipt anchor |
+
+## Required Status Boundary
+
+C2C-001 is a target-state registry specification.
+
+It is not:
+
+- runtime proof;
+- external audit approval;
+- legal certification;
+- production readiness;
+- public claim approval;
+- automatic canon;
+- proof that every row is verified.
+
+## Target Runtime Behavior
+
+When an actor proposes an action, the system should:
+
+1. identify the actor’s declared office;
+2. load the matching concordance entry;
+3. compare requested action against allowed and prohibited actions;
+4. verify required authority level;
+5. verify consequence class;
+6. verify required receipt path;
+7. HOLD if any required boundary fails;
+8. return a failure receipt explaining the office break.
+
+## Failure Modes
+
+| Failure mode | Meaning | Required response |
+|---|---|---|
+| role_collapse | Office silently becomes sibling office | HOLD |
+| office_overreach | Actor tries action outside allowed scope | HOLD |
+| primitive_inversion_violation | Office performs inverse/sibling function | HOLD |
+| authority_substitution | Pattern, receipt, confidence, or convergence treated as authority | DENY/HOLD |
+| receipt_permission_collapse | Receipt treated as future permission | HOLD |
+| context_authority_collapse | Context treated as authorization | HOLD |
+| model_executor_collapse | Model attempts execution privileges | DENY |
+| witness_authorizer_collapse | Witness attempts to authorize | DENY |
+| tool_sovereignty_collapse | Tool access treated as authority | DENY |
+
+## Implementation Boundary
+
+C2C-001 should be implemented only after concordance rows are evidence-labeled and reviewed.
+
+Recommended implementation sequence:
+
+```text
+1. repo-safe specification
+2. JSON schema
+3. sample concordance matrix
+4. validator design
+5. failing tests
+6. runtime validator
+7. receipt integration
+8. human ratification
+```
+
+## Keeper
+
+This packet is not claiming the lock is already installed.
+
+It names the lock the system is designed to install.

--- a/docs/c2c/office-integrity-validator-target-v0.1.md
+++ b/docs/c2c/office-integrity-validator-target-v0.1.md
@@ -1,0 +1,74 @@
+---
+id: C2C-001-VALIDATOR
+title: Office Integrity Validator Target
+version: v0.1
+status: TARGET_STATE_SPEC
+runtime_status: not_implemented_by_this_file
+claim_level: validator design target
+authority: Brian Kent Rasmussen / human SourcePoint
+---
+
+# Office Integrity Validator — Target-State Design v0.1
+
+## Purpose
+
+The Office Integrity Validator is the future runtime check that verifies a proposed actor/action pair against the C2C-001 Concordance Control Registry.
+
+It prevents category collapse before execution.
+
+## Target Input
+
+```json
+{
+  "actor_id": "bondi",
+  "declared_office": "formation_layer",
+  "requested_action": "authorize_action",
+  "consequence_class": "runtime_action",
+  "authority_context": {
+    "authority_level": "none_observational"
+  }
+}
+```
+
+## Target Output — Fail/HOLD Example
+
+```json
+{
+  "status": "FAIL_HOLD",
+  "reason": "office_overreach",
+  "message": "Declared office 'formation_layer' may structure candidate packets but may not authorize action.",
+  "required_repair_path": "REQUIRE_FRESH_AUTHORITY",
+  "receipt_type": "hold_receipt"
+}
+```
+
+## Target Output — Pass Example
+
+```json
+{
+  "status": "PASS",
+  "message": "Office integrity verified for declared office and requested action.",
+  "receipt_type": "classification_receipt"
+}
+```
+
+## Required Checks
+
+A production implementation should verify:
+
+1. declared office exists in concordance;
+2. requested action is listed in allowed actions;
+3. requested action is not prohibited;
+4. consequence class is permitted;
+5. required authority level is satisfied;
+6. required receipt type can be produced;
+7. inversion/sibling collapse is not occurring;
+8. failure mode maps to a repair path.
+
+## Non-Claims
+
+This file does not implement runtime validation.
+
+It does not prove security enforcement, audit approval, public certification, or production readiness.
+
+It defines the target behavior for a future implementation.

--- a/schemas/concordance/concordance-entry.schema.json
+++ b/schemas/concordance/concordance-entry.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://one-rio-muss.local/schemas/concordance/concordance-entry.schema.json",
+  "title": "C2C-001 Concordance Entry",
+  "description": "Target-state schema for mapping a primitive pattern to its allowed office, actions, boundaries, inversions, evidence status, and repair path.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "primitive_id",
+    "primitive_name",
+    "active_office",
+    "office_function",
+    "allowed_actions",
+    "prohibited_actions",
+    "required_authority_level",
+    "required_receipt_type",
+    "failure_mode",
+    "repair_path",
+    "evidence_level",
+    "status"
+  ],
+  "properties": {
+    "primitive_id": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_-]+$"
+    },
+    "primitive_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "active_office": {
+      "type": "string",
+      "minLength": 1
+    },
+    "office_function": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_actions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "prohibited_actions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "required_authority_level": {
+      "type": "string",
+      "enum": [
+        "none_observational",
+        "policy_profile",
+        "human_confirmation",
+        "human_signature",
+        "fresh_scoped_authority_event"
+      ]
+    },
+    "consequence_classes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "private_reflection",
+          "internal_architecture",
+          "repo_documentation",
+          "runtime_action",
+          "external_communication",
+          "public_claim",
+          "financial_action",
+          "legal_or_compliance",
+          "physical_world_action"
+        ]
+      },
+      "default": []
+    },
+    "required_receipt_type": {
+      "type": "string",
+      "enum": [
+        "none",
+        "classification_receipt",
+        "hold_receipt",
+        "refusal_receipt",
+        "authority_receipt",
+        "execution_receipt",
+        "outcome_receipt",
+        "delta_receipt"
+      ]
+    },
+    "inversion_or_sibling": {
+      "type": "string"
+    },
+    "failure_mode": {
+      "type": "string",
+      "enum": [
+        "role_collapse",
+        "office_overreach",
+        "primitive_inversion_violation",
+        "authority_substitution",
+        "receipt_permission_collapse",
+        "context_authority_collapse",
+        "model_executor_collapse",
+        "witness_authorizer_collapse",
+        "tool_sovereignty_collapse"
+      ]
+    },
+    "repair_path": {
+      "type": "string",
+      "enum": [
+        "HOLD_AND_RETURN",
+        "DENY_AND_RECEIPT",
+        "REQUEST_HUMAN_CLARIFICATION",
+        "REQUIRE_FRESH_AUTHORITY",
+        "ROUTE_TO_CANONIZATION_GATE",
+        "ROUTE_TO_CONCORDANCE_REVIEW"
+      ]
+    },
+    "evidence_level": {
+      "type": "string",
+      "enum": [
+        "DRIVE_VERIFIED",
+        "DRIVE_VERIFIED_PARTIAL",
+        "REPO_VERIFIED",
+        "THREAD_SUPPORTED",
+        "THREAD_SUPPORTED_PENDING_DOC_READ",
+        "PENDING_DOC_READ",
+        "TARGET_STATE_SPEC"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "LOCKED_COMPONENT",
+        "TARGET_STATE_SPEC",
+        "ACTIVE_ALIAS",
+        "HOLD_AS_ALIAS",
+        "MERGE_ALIAS",
+        "RETIRE_ALIAS",
+        "DO_NOT_CANONIZE_AS_GATE",
+        "PENDING_REVIEW"
+      ]
+    },
+    "source_anchor": {
+      "type": "string"
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Close the current naming/build loop by adding a repo-safe target-state spec for C2C-001: the Concordance Control Registry.
- Convert the name → office → function → inversion → boundary pattern into schema-ready implementation material without claiming runtime enforcement.
- Preserve a strict status boundary: this PR names the lock the system is designed to install; it does not claim the lock is already installed.

### Description

Adds four new target-state files:

- `docs/c2c/c2c-001-concordance-control-registry-v0.1.md`
- `schemas/concordance/concordance-entry.schema.json`
- `config/concordance_matrix.sample.json`
- `docs/c2c/office-integrity-validator-target-v0.1.md`

The packet defines:

- C2C-001 as a Concordance Control Registry target-state spec.
- Concordance entries as machine-readable mappings of primitive → office → allowed/prohibited actions → authority level → receipt type → failure mode → repair path.
- Office Integrity Validator target behavior for preventing role collapse and office overreach.
- Explicit non-claims for runtime proof, audit approval, public certification, production readiness, and canon status.

### Scope boundary

This is a docs/schema/sample-config PR only.

It does **not**:

- modify runtime gateway code;
- modify deployment configuration;
- claim production implementation;
- certify security enforcement;
- add validator runtime logic;
- alter existing RIO/Sentinel/MUS execution behavior.

### Testing

No automated tests were run because this PR does not modify executable runtime code. The next implementation step would be failing tests for an actual `officeIntegrityValidator` module after repo conventions are inspected and approved.