### PR TITLE
feat(prime): add first bounded runtime bridge

### DIFF
--- a/.github/workflows/prime-runtime-bridge.yml
+++ b/.github/workflows/prime-runtime-bridge.yml
@@ -1,0 +1,32 @@
+name: Prime Runtime Bridge
+
+on:
+  pull_request:
+    paths:
+      - "gateway/prime/**"
+      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/package.json"
+      - ".github/workflows/prime-runtime-bridge.yml"
+  push:
+    branches: [main]
+    paths:
+      - "gateway/prime/**"
+      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/package.json"
+      - ".github/workflows/prime-runtime-bridge.yml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gateway
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: gateway/package-lock.json
+      - run: npm ci
+      - run: npm run test:prime

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -13,7 +13,8 @@
     "test:spgm": "node --test tests/spgm-intake.test.mjs tests/spgm-schema.test.mjs tests/spgm-route.test.mjs tests/spgm-receipt-event.test.mjs tests/spgm-policy-context.test.mjs tests/spgm-policy-adapter.test.mjs tests/spgm-policy-bridge.test.mjs tests/spgm-policy-engine-integration.test.mjs",
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
-    "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs"
+    "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/README.md
+++ b/gateway/prime/README.md
@@ -1,0 +1,55 @@
+# Prime → RIO Runtime Bridge v0.1
+
+This bridge accepts compiled Prime Relational IR and executes one deliberately bounded runtime operation:
+
+```text
+prime.echo
+```
+
+The operation has no external side effects. It proves the first end-to-end crossing between the executable Prime language and the active RIO receipt runtime.
+
+## Flow
+
+```text
+Prime expression
+→ Relational IR
+→ explicit authorization envelope
+→ RIO bounded echo execution
+→ native RIO five-hash receipt
+→ receipt verification
+→ Prime-readable return
+```
+
+## Run the verification
+
+From `gateway/`:
+
+```bash
+npm run test:prime
+```
+
+## Accepted authorization
+
+```json
+{
+  "decision": "approved",
+  "action": "prime.echo",
+  "authorized_by": "human-authority-id",
+  "expires_at": "future ISO-8601 timestamp"
+}
+```
+
+The bridge rejects denied, missing, expired, or differently scoped authorization.
+
+## Successful return
+
+The result contains:
+
+- the returned Prime expression;
+- the RIO intent, governance record, authorization record, and execution record;
+- a native RIO receipt covering all four artifact hashes;
+- independent receipt verification.
+
+## Current boundary
+
+`prime.echo` preserves and returns the compiled path. It does not call an external connector or create an external-world side effect. The next bridge version may replace the echo connector with one explicitly bounded tool operation while retaining the same authorization and receipt contract.

--- a/gateway/prime/bridge.mjs
+++ b/gateway/prime/bridge.mjs
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import {
+  generateReceipt,
+  hashAuthorization,
+  hashExecution,
+  hashGovernance,
+  hashIntent,
+  verifyReceipt,
+} from "../receipts/receipts.mjs";
+
+const REQUIRED_ACTION = "prime.echo";
+
+function assertObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+}
+
+export function validatePrimeIr(ir) {
+  assertObject(ir, "Prime IR");
+  if (!Array.isArray(ir.symbols) || ir.symbols.length < 1) {
+    throw new TypeError("Prime IR symbols must be a non-empty array");
+  }
+  if (!Array.isArray(ir.transitions)) {
+    throw new TypeError("Prime IR transitions must be an array");
+  }
+  if (ir.transitions.length !== Math.max(0, ir.symbols.length - 1)) {
+    throw new TypeError("Prime IR transition count does not match symbol path");
+  }
+  return ir;
+}
+
+export function validateAuthorization(authorization, now = new Date()) {
+  assertObject(authorization, "Authorization");
+  if (authorization.decision !== "approved") {
+    throw new Error("Prime runtime bridge requires explicit approved authorization");
+  }
+  if (authorization.action !== REQUIRED_ACTION) {
+    throw new Error(`Authorization action must be ${REQUIRED_ACTION}`);
+  }
+  if (!authorization.authorized_by) {
+    throw new Error("Authorization requires authorized_by");
+  }
+  if (!authorization.expires_at) {
+    throw new Error("Authorization requires expires_at");
+  }
+  const expiry = new Date(authorization.expires_at);
+  if (Number.isNaN(expiry.getTime()) || expiry <= now) {
+    throw new Error("Authorization is expired or invalid");
+  }
+  return authorization;
+}
+
+export function executePrimeEcho({ ir, authorization, agent_id = "prime-compiler" }) {
+  validatePrimeIr(ir);
+  validateAuthorization(authorization);
+
+  const intent = {
+    intent_id: randomUUID(),
+    action: REQUIRED_ACTION,
+    agent_id,
+    parameters: {
+      source_expression: ir.source_expression,
+      lexicon_version: ir.lexicon_version,
+      symbols: ir.symbols,
+      transitions: ir.transitions,
+      closed_path: Boolean(ir.closed_path),
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  const governance = {
+    intent_id: intent.intent_id,
+    status: "allowed",
+    risk_level: "LOW",
+    requires_approval: true,
+    checks: {
+      prime_ir_valid: true,
+      bounded_action: REQUIRED_ACTION,
+      authorization_present: true,
+      external_side_effects: false,
+    },
+  };
+
+  const authorizationRecord = {
+    intent_id: intent.intent_id,
+    decision: authorization.decision,
+    authorized_by: authorization.authorized_by,
+    timestamp: authorization.timestamp || new Date().toISOString(),
+    conditions: {
+      action: REQUIRED_ACTION,
+      expires_at: authorization.expires_at,
+      scope: authorization.scope || "prime-runtime-bridge-v0.1",
+    },
+  };
+
+  const execution = {
+    intent_id: intent.intent_id,
+    action: REQUIRED_ACTION,
+    connector: "prime-runtime-bridge",
+    timestamp: new Date().toISOString(),
+    result: {
+      status: "EXECUTED",
+      effect: "ECHO_ONLY",
+      source_expression: ir.source_expression,
+      returned_symbols: [...ir.symbols],
+      crossing_count: ir.transitions.filter(
+        (step) => step.direction !== "NO_BOUNDARY_CROSSING",
+      ).length,
+      external_side_effects: false,
+    },
+  };
+
+  const receipt = generateReceipt({
+    intent_hash: hashIntent(intent),
+    governance_hash: hashGovernance(governance),
+    authorization_hash: hashAuthorization(authorizationRecord),
+    execution_hash: hashExecution(execution),
+    intent_id: intent.intent_id,
+    action: intent.action,
+    agent_id: intent.agent_id,
+    authorized_by: authorizationRecord.authorized_by,
+    ingestion: {
+      source: "prime",
+      channel: "prime-runtime-bridge",
+      source_message_id: ir.source_expression || null,
+      timestamp: intent.timestamp,
+    },
+    policy: {
+      evaluated: true,
+      decision: "ALLOW",
+      rules_triggered: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ECHO_ONLY"],
+      policy_pack: "prime-runtime-bridge-v0.1",
+    },
+  });
+
+  const verification = verifyReceipt(receipt);
+  if (!verification.valid) {
+    throw new Error("Generated RIO receipt failed verification");
+  }
+
+  return {
+    status: "RETURNED",
+    prime: {
+      source_expression: ir.source_expression,
+      lexicon_version: ir.lexicon_version,
+      returned_expression: ir.symbols.join(" -> "),
+    },
+    runtime: {
+      intent,
+      governance,
+      authorization: authorizationRecord,
+      execution,
+    },
+    receipt,
+    receipt_verification: verification,
+  };
+}

--- a/gateway/tests/prime-runtime-bridge.test.mjs
+++ b/gateway/tests/prime-runtime-bridge.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  executePrimeEcho,
+  validateAuthorization,
+  validatePrimeIr,
+} from "../prime/bridge.mjs";
+
+const IR = {
+  source_expression: "7 -> 8 -> 7",
+  lexicon_version: "prime-experimental-v0.1",
+  symbols: ["7", "8", "7"],
+  transitions: [
+    { origin: "7", destination: "8", direction: "OUTWARD_TO_BOUNDARY" },
+    { origin: "8", destination: "7", direction: "INWARD_FROM_BOUNDARY" },
+  ],
+  closed_path: true,
+};
+
+function approval(overrides = {}) {
+  return {
+    decision: "approved",
+    action: "prime.echo",
+    authorized_by: "human-test-authority",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+test("executes a bounded Prime echo and returns a valid native RIO receipt", () => {
+  const result = executePrimeEcho({ ir: IR, authorization: approval() });
+
+  assert.equal(result.status, "RETURNED");
+  assert.equal(result.prime.returned_expression, "7 -> 8 -> 7");
+  assert.equal(result.runtime.execution.result.effect, "ECHO_ONLY");
+  assert.equal(result.runtime.execution.result.external_side_effects, false);
+  assert.equal(result.runtime.execution.result.crossing_count, 2);
+  assert.equal(result.receipt.action, "prime.echo");
+  assert.equal(result.receipt_verification.valid, true);
+  assert.equal(result.receipt.policy.decision, "ALLOW");
+});
+
+test("fails closed without explicit approval", () => {
+  assert.throws(
+    () => executePrimeEcho({ ir: IR, authorization: approval({ decision: "denied" }) }),
+    /explicit approved authorization/,
+  );
+});
+
+test("fails closed when authorization scope names another action", () => {
+  assert.throws(
+    () => executePrimeEcho({ ir: IR, authorization: approval({ action: "email.send" }) }),
+    /Authorization action must be prime.echo/,
+  );
+});
+
+test("fails closed on expired authorization", () => {
+  assert.throws(
+    () => validateAuthorization(approval({ expires_at: "2020-01-01T00:00:00.000Z" })),
+    /expired or invalid/,
+  );
+});
+
+test("rejects malformed Prime IR before execution", () => {
+  assert.throws(
+    () => validatePrimeIr({ ...IR, transitions: [] }),
+    /transition count does not match/,
+  );
+});


### PR DESCRIPTION
## Summary

Connects compiled Prime Relational IR to the active RIO runtime through one deliberately bounded operation: `prime.echo`.

The bridge accepts Prime IR plus an explicit authorization envelope, executes an echo-only runtime action with no external side effects, generates the native RIO five-hash receipt, verifies it, and returns the Prime-readable path.

## Flow

```text
Prime expression
→ Relational IR
→ explicit authorization
→ RIO bounded echo execution
→ native RIO receipt
→ receipt verification
→ Prime-readable return
```

## Implementation

- adds `gateway/prime/bridge.mjs`
- validates Prime IR shape before execution
- requires explicit approved, unexpired authorization scoped exactly to `prime.echo`
- executes only `ECHO_ONLY` with `external_side_effects: false`
- records intent, governance, authorization, and execution artifacts
- generates a native RIO receipt using the existing receipt engine
- verifies the generated receipt before returning
- adds five fail-closed and successful-path tests
- adds `npm run test:prime`
- adds dedicated GitHub Actions verification
- documents the bridge contract and next boundary

## Acceptance checks

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- `7 -> 8 -> 7` returns through the active runtime
- crossing count is preserved as `2`
- the operation has no external side effect
- the native RIO receipt verifies
- denied authorization fails closed
- wrong action scope fails closed
- expired authorization fails closed
- malformed Prime IR fails before execution

## Boundary

This is the smallest real Prime-to-RIO runtime crossing. It does not yet expose an HTTP route or invoke an external connector. The next increment can place this same verified bridge behind an authenticated endpoint, then replace `prime.echo` with one explicitly bounded tool action.