### PR TITLE
superseded: authenticated Prime echo endpoint

### DIFF
--- a/.github/workflows/prime-runtime-bridge.yml
+++ b/.github/workflows/prime-runtime-bridge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     paths:
       - "gateway/prime/**"
-      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/routes/prime-api-v1.mjs"
+      - "gateway/routes/spgm-api-v1-govern.mjs"
+      - "gateway/tests/prime-*.test.mjs"
       - "gateway/package.json"
       - ".github/workflows/prime-runtime-bridge.yml"
   push:
     branches: [main]
     paths:
       - "gateway/prime/**"
-      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/routes/prime-api-v1.mjs"
+      - "gateway/routes/spgm-api-v1-govern.mjs"
+      - "gateway/tests/prime-*.test.mjs"
       - "gateway/package.json"
       - ".github/workflows/prime-runtime-bridge.yml"
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-api-v1.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/API_V1_EXECUTE.md
+++ b/gateway/prime/API_V1_EXECUTE.md
@@ -1,0 +1,53 @@
+# Prime API v1 Execute
+
+Authenticated endpoint:
+
+```text
+POST /api/v1/prime/execute
+```
+
+Required gateway conditions:
+
+- valid JWT owner or API key with `write` scope;
+- resolved active principal with the `executor` role;
+- Prime Relational IR;
+- explicit, unexpired authorization scoped to `prime.echo`.
+
+Request:
+
+```json
+{
+  "ir": {
+    "source_expression": "7 -> 8 -> 7",
+    "lexicon_version": "prime-experimental-v0.1",
+    "symbols": ["7", "8", "7"],
+    "transitions": [
+      {"origin": "7", "destination": "8", "direction": "OUTWARD_TO_BOUNDARY"},
+      {"origin": "8", "destination": "7", "direction": "INWARD_FROM_BOUNDARY"}
+    ],
+    "closed_path": true
+  },
+  "authorization": {
+    "decision": "approved",
+    "action": "prime.echo",
+    "authorized_by": "human-root",
+    "expires_at": "<future ISO-8601 timestamp>"
+  }
+}
+```
+
+Successful response includes:
+
+- Prime-readable returned expression;
+- runtime intent, governance, authorization, and execution records;
+- native RIO five-hash receipt;
+- receipt verification result;
+- authenticated principal identity.
+
+Current operation boundary:
+
+```text
+prime.echo
+```
+
+It has no external side effects. This endpoint proves authenticated transport into the active gateway before a reversible tool connector is introduced.

--- a/gateway/routes/prime-api-v1.mjs
+++ b/gateway/routes/prime-api-v1.mjs
@@ -1,0 +1,60 @@
+import { Router } from "express";
+import { requireScope } from "../security/api-auth.mjs";
+import { requireRole } from "../security/principals.mjs";
+import { executePrimeEcho } from "../prime/bridge.mjs";
+
+const router = Router();
+
+function classifyBridgeError(error) {
+  if (error instanceof TypeError) {
+    return { statusCode: 400, code: "PRIME_IR_INVALID" };
+  }
+  if (
+    error.message.includes("authorization") ||
+    error.message.includes("Authorization")
+  ) {
+    return { statusCode: 403, code: "PRIME_AUTHORIZATION_INVALID" };
+  }
+  return { statusCode: 500, code: "PRIME_RUNTIME_ERROR" };
+}
+
+export function handlePrimeExecute(req, res) {
+  try {
+    const { ir, authorization } = req.body || {};
+    const agentId =
+      req.principal?.principal_id ||
+      req.apiKey?.owner_id ||
+      req.user?.sub ||
+      "unknown-principal";
+
+    const result = executePrimeEcho({
+      ir,
+      authorization,
+      agent_id: agentId,
+    });
+
+    return res.status(200).json({
+      ...result,
+      api_version: "v1",
+      route: "/api/v1/prime/execute",
+      authenticated_principal: agentId,
+    });
+  } catch (error) {
+    const classification = classifyBridgeError(error);
+    return res.status(classification.statusCode).json({
+      error: classification.code,
+      message: error.message,
+      fail_mode: "closed",
+      api_version: "v1",
+    });
+  }
+}
+
+router.post(
+  "/prime/execute",
+  requireScope("write"),
+  requireRole("executor"),
+  handlePrimeExecute,
+);
+
+export default router;

--- a/gateway/routes/spgm-api-v1-govern.mjs
+++ b/gateway/routes/spgm-api-v1-govern.mjs
@@ -1,16 +1,19 @@
 /**
- * SPG-M API v1 Govern Bridge Route
+ * API v1 pre-route bridges.
  *
- * Intercepts POST /api/v1/intents/:id/govern only when SPG-M review
- * metadata is present. Otherwise it passes through to the standard API v1
- * govern route.
+ * SPG-M intercepts governed intents only when review metadata is present.
+ * Prime exposes a bounded authenticated execution route backed by the
+ * verified Prime runtime bridge.
  */
 import { Router } from "express";
 import { requireScope } from "../security/api-auth.mjs";
 import { requireRole } from "../security/principals.mjs";
 import { handleSpgmGovernRequest } from "./spgm-govern.mjs";
+import primeApiV1Routes from "./prime-api-v1.mjs";
 
 const router = Router();
+
+router.use(primeApiV1Routes);
 
 router.post("/intents/:id/govern", requireScope("write"), requireRole("proposer", "executor"), (req, res, next) => {
   try {

--- a/gateway/tests/prime-api-v1.test.mjs
+++ b/gateway/tests/prime-api-v1.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import primeRouter, { handlePrimeExecute } from "../routes/prime-api-v1.mjs";
+
+const IR = {
+  source_expression: "7 -> 8 -> 7",
+  lexicon_version: "prime-experimental-v0.1",
+  symbols: ["7", "8", "7"],
+  transitions: [
+    { origin: "7", destination: "8", direction: "OUTWARD_TO_BOUNDARY" },
+    { origin: "8", destination: "7", direction: "INWARD_FROM_BOUNDARY" },
+  ],
+  closed_path: true,
+};
+
+function authorization(overrides = {}) {
+  return {
+    decision: "approved",
+    action: "prime.echo",
+    authorized_by: "human-root",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function responseRecorder() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+test("router exposes POST /prime/execute", () => {
+  const layer = primeRouter.stack.find((entry) => entry.route?.path === "/prime/execute");
+  assert.ok(layer);
+  assert.deepEqual(layer.route.methods, { post: true });
+});
+
+test("authenticated executor receives verified Prime runtime return", () => {
+  const req = {
+    body: { ir: IR, authorization: authorization() },
+    principal: { principal_id: "gateway-exec", primary_role: "executor", status: "active" },
+  };
+  const res = responseRecorder();
+
+  handlePrimeExecute(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.status, "RETURNED");
+  assert.equal(res.body.prime.returned_expression, "7 -> 8 -> 7");
+  assert.equal(res.body.runtime.execution.result.external_side_effects, false);
+  assert.equal(res.body.receipt_verification.valid, true);
+  assert.equal(res.body.authenticated_principal, "gateway-exec");
+  assert.equal(res.body.route, "/api/v1/prime/execute");
+});
+
+test("malformed IR fails closed with 400", () => {
+  const req = {
+    body: { ir: { symbols: [] }, authorization: authorization() },
+    principal: { principal_id: "gateway-exec" },
+  };
+  const res = responseRecorder();
+
+  handlePrimeExecute(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, "PRIME_IR_INVALID");
+  assert.equal(res.body.fail_mode, "closed");
+});
+
+test("denied authorization fails closed with 403", () => {
+  const req = {
+    body: { ir: IR, authorization: authorization({ decision: "denied" }) },
+    principal: { principal_id: "gateway-exec" },
+  };
+  const res = responseRecorder();
+
+  handlePrimeExecute(req, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.error, "PRIME_AUTHORIZATION_INVALID");
+  assert.equal(res.body.fail_mode, "closed");
+});


### PR DESCRIPTION
Superseded by merged PR #182 and the fresh live gateway wiring branch. The reversible Prime router now defines the active route shape; this earlier echo-only endpoint is no longer the correct integration target.