### PR TITLE
feat(prime): add authenticated reversible sandbox action

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/SANDBOX_RUNTIME_V0_2.md
+++ b/gateway/prime/SANDBOX_RUNTIME_V0_2.md
@@ -1,0 +1,40 @@
+# Prime Authenticated Sandbox Runtime v0.2
+
+This slice adds the first reversible Prime tool consequence.
+
+## HTTP surface
+
+When mounted under `/api/v1`, the router exposes:
+
+```text
+POST /api/v1/prime/execute
+POST /api/v1/prime/rollback
+```
+
+The production router uses the gateway's existing `requireScope("write")` middleware. Tests inject equivalent pass/deny middleware to prove both authenticated and unauthenticated behavior without requiring PostgreSQL startup.
+
+## Set action
+
+```json
+{
+  "ir": { "source_expression": "7 -> 8 -> 7", "symbols": ["7", "8", "7"], "transitions": [{}, {}] },
+  "authorization": {
+    "decision": "approved",
+    "action": "prime.sandbox.set",
+    "authorized_by": "human-authority-id",
+    "expires_at": "future ISO timestamp"
+  },
+  "key": "demo.signal",
+  "value": "7 -> 8 -> 7"
+}
+```
+
+The response includes a native RIO receipt and a single-use rollback token.
+
+## Rollback action
+
+Rollback requires a second, action-specific approval for `prime.sandbox.rollback`. It verifies that the current state still matches the receipted mutation before restoring the prior state. Replayed rollback tokens and intervening unreceipted state changes fail closed.
+
+## Boundary
+
+The sandbox is process-local and has no external side effects. The router is implemented and independently exercised as an Express HTTP surface. A separate reviewed wiring change is required to mount it in `gateway/server.mjs` after the runtime's startup and database integration path is selected.

--- a/gateway/prime/sandbox.mjs
+++ b/gateway/prime/sandbox.mjs
@@ -1,0 +1,141 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  generateReceipt,
+  hashAuthorization,
+  hashExecution,
+  hashGovernance,
+  hashIntent,
+  verifyReceipt,
+} from "../receipts/receipts.mjs";
+import { validatePrimeIr } from "./bridge.mjs";
+
+const SET_ACTION = "prime.sandbox.set";
+const ROLLBACK_ACTION = "prime.sandbox.rollback";
+
+function sha256(value) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function validateAuthorization(authorization, action, now = new Date()) {
+  if (!authorization || authorization.decision !== "approved") {
+    throw new Error("Explicit approved authorization is required");
+  }
+  if (authorization.action !== action) {
+    throw new Error(`Authorization action must be ${action}`);
+  }
+  if (!authorization.authorized_by) {
+    throw new Error("Authorization requires authorized_by");
+  }
+  const expiry = new Date(authorization.expires_at);
+  if (!authorization.expires_at || Number.isNaN(expiry.getTime()) || expiry <= now) {
+    throw new Error("Authorization is expired or invalid");
+  }
+}
+
+function receiptFor({ action, ir, authorization, execution, rules }) {
+  const timestamp = new Date().toISOString();
+  const intent = {
+    intent_id: randomUUID(),
+    action,
+    agent_id: "prime-compiler",
+    parameters: { source_expression: ir.source_expression, symbols: ir.symbols },
+    timestamp,
+  };
+  const governance = {
+    intent_id: intent.intent_id,
+    status: "allowed",
+    risk_level: "LOW",
+    requires_approval: true,
+    checks: { prime_ir_valid: true, bounded_action: action, reversible: true },
+  };
+  const authorizationRecord = {
+    intent_id: intent.intent_id,
+    decision: "approved",
+    authorized_by: authorization.authorized_by,
+    timestamp: authorization.timestamp || timestamp,
+    conditions: { action, expires_at: authorization.expires_at },
+  };
+  const executionRecord = {
+    intent_id: intent.intent_id,
+    action,
+    connector: "prime-sandbox",
+    timestamp,
+    result: execution,
+  };
+  const receipt = generateReceipt({
+    intent_hash: hashIntent(intent),
+    governance_hash: hashGovernance(governance),
+    authorization_hash: hashAuthorization(authorizationRecord),
+    execution_hash: hashExecution(executionRecord),
+    intent_id: intent.intent_id,
+    action,
+    agent_id: intent.agent_id,
+    authorized_by: authorization.authorized_by,
+    ingestion: { source: "prime", channel: "prime-sandbox", source_message_id: ir.source_expression, timestamp },
+    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-sandbox-v0.2" },
+  });
+  const verification = verifyReceipt(receipt);
+  if (!verification.valid) throw new Error("Generated RIO receipt failed verification");
+  return { intent, governance, authorization: authorizationRecord, execution: executionRecord, receipt, verification };
+}
+
+export class PrimeSandbox {
+  constructor() {
+    this.values = new Map();
+    this.rollbacks = new Map();
+  }
+
+  get(key) {
+    return this.values.get(key);
+  }
+
+  set({ ir, authorization, key, value }) {
+    validatePrimeIr(ir);
+    validateAuthorization(authorization, SET_ACTION);
+    if (typeof key !== "string" || !/^[a-zA-Z0-9._-]{1,64}$/.test(key)) {
+      throw new Error("Sandbox key is invalid");
+    }
+    if (typeof value !== "string" || value.length > 4096) {
+      throw new Error("Sandbox value must be a string up to 4096 characters");
+    }
+    const hadPrevious = this.values.has(key);
+    const previousValue = this.values.get(key);
+    this.values.set(key, value);
+    const rollbackToken = randomUUID();
+    this.rollbacks.set(rollbackToken, { key, hadPrevious, previousValue, expectedHash: sha256(value), used: false });
+    const execution = {
+      status: "EXECUTED",
+      effect: "SANDBOX_SET",
+      key,
+      value_hash: sha256(value),
+      reversible: true,
+      rollback_token: rollbackToken,
+      external_side_effects: false,
+    };
+    return { status: "RETURNED", operation: SET_ACTION, execution, ...receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SANDBOX_ONLY", "ROLLBACK_AVAILABLE"] }) };
+  }
+
+  rollback({ ir, authorization, rollback_token }) {
+    validatePrimeIr(ir);
+    validateAuthorization(authorization, ROLLBACK_ACTION);
+    const record = this.rollbacks.get(rollback_token);
+    if (!record || record.used) throw new Error("Rollback token is invalid or already used");
+    if (sha256(this.values.get(record.key)) !== record.expectedHash) {
+      throw new Error("Sandbox state changed after the receipted mutation");
+    }
+    if (record.hadPrevious) this.values.set(record.key, record.previousValue);
+    else this.values.delete(record.key);
+    record.used = true;
+    const execution = {
+      status: "EXECUTED",
+      effect: "SANDBOX_ROLLBACK",
+      key: record.key,
+      restored_previous_state: true,
+      rollback_token,
+      external_side_effects: false,
+    };
+    return { status: "RETURNED", operation: ROLLBACK_ACTION, execution, ...receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "STATE_RESTORED"] }) };
+  }
+}
+
+export const primeSandbox = new PrimeSandbox();

--- a/gateway/prime/sandbox.mjs
+++ b/gateway/prime/sandbox.mjs
@@ -79,6 +79,22 @@ function receiptFor({ action, ir, authorization, execution, rules }) {
   return { intent, governance, authorization: authorizationRecord, execution: executionRecord, receipt, verification };
 }
 
+function responseFor({ status, operation, execution, artifacts }) {
+  return {
+    status,
+    operation,
+    execution,
+    runtime: {
+      intent: artifacts.intent,
+      governance: artifacts.governance,
+      authorization: artifacts.authorization,
+      execution: artifacts.execution,
+    },
+    receipt: artifacts.receipt,
+    verification: artifacts.verification,
+  };
+}
+
 export class PrimeSandbox {
   constructor() {
     this.values = new Map();
@@ -112,7 +128,8 @@ export class PrimeSandbox {
       rollback_token: rollbackToken,
       external_side_effects: false,
     };
-    return { status: "RETURNED", operation: SET_ACTION, execution, ...receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SANDBOX_ONLY", "ROLLBACK_AVAILABLE"] }) };
+    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SANDBOX_ONLY", "ROLLBACK_AVAILABLE"] });
+    return responseFor({ status: "RETURNED", operation: SET_ACTION, execution, artifacts });
   }
 
   rollback({ ir, authorization, rollback_token }) {
@@ -134,7 +151,8 @@ export class PrimeSandbox {
       rollback_token,
       external_side_effects: false,
     };
-    return { status: "RETURNED", operation: ROLLBACK_ACTION, execution, ...receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "STATE_RESTORED"] }) };
+    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "STATE_RESTORED"] });
+    return responseFor({ status: "RETURNED", operation: ROLLBACK_ACTION, execution, artifacts });
   }
 }
 

--- a/gateway/routes/prime-runtime.mjs
+++ b/gateway/routes/prime-runtime.mjs
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import { requireScope } from "../security/api-auth.mjs";
+import { primeSandbox } from "../prime/sandbox.mjs";
+
+export function createPrimeRuntimeRouter({ sandbox = primeSandbox, requireWrite = requireScope("write") } = {}) {
+  const router = Router();
+
+  router.post("/prime/execute", requireWrite, (req, res) => {
+    try {
+      const result = sandbox.set(req.body || {});
+      res.status(201).json(result);
+    } catch (error) {
+      res.status(400).json({ error: error.message, status: "BLOCKED" });
+    }
+  });
+
+  router.post("/prime/rollback", requireWrite, (req, res) => {
+    try {
+      const result = sandbox.rollback(req.body || {});
+      res.json(result);
+    } catch (error) {
+      res.status(400).json({ error: error.message, status: "BLOCKED" });
+    }
+  });
+
+  return router;
+}
+
+export default createPrimeRuntimeRouter();

--- a/gateway/tests/prime-authenticated-sandbox.test.mjs
+++ b/gateway/tests/prime-authenticated-sandbox.test.mjs
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+
+import { createPrimeRuntimeRouter } from "../routes/prime-runtime.mjs";
+import { PrimeSandbox } from "../prime/sandbox.mjs";
+
+const IR = {
+  source_expression: "7 -> 8 -> 7",
+  lexicon_version: "prime-experimental-v0.1",
+  symbols: ["7", "8", "7"],
+  transitions: [
+    { origin: "7", destination: "8", direction: "OUTWARD_TO_BOUNDARY" },
+    { origin: "8", destination: "7", direction: "INWARD_FROM_BOUNDARY" },
+  ],
+  closed_path: true,
+};
+
+function approval(action) {
+  return {
+    decision: "approved",
+    action,
+    authorized_by: "human-test-authority",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+  };
+}
+
+async function startApp({ authenticated = true } = {}) {
+  const sandbox = new PrimeSandbox();
+  const requireWrite = authenticated
+    ? (_req, _res, next) => next()
+    : (_req, res) => res.status(401).json({ error: "Authentication required." });
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1", createPrimeRuntimeRouter({ sandbox, requireWrite }));
+  const server = await new Promise((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  return { sandbox, server, base: `http://127.0.0.1:${server.address().port}` };
+}
+
+async function post(base, path, body) {
+  const response = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+test("authenticated Prime sandbox set and rollback produce verified RIO receipts", async (t) => {
+  const { sandbox, server, base } = await startApp();
+  t.after(() => server.close());
+
+  const set = await post(base, "/api/v1/prime/execute", {
+    ir: IR,
+    authorization: approval("prime.sandbox.set"),
+    key: "demo.signal",
+    value: "7 -> 8 -> 7",
+  });
+  assert.equal(set.status, 201);
+  assert.equal(set.body.operation, "prime.sandbox.set");
+  assert.equal(set.body.verification.valid, true);
+  assert.equal(sandbox.get("demo.signal"), "7 -> 8 -> 7");
+
+  const rollback = await post(base, "/api/v1/prime/rollback", {
+    ir: IR,
+    authorization: approval("prime.sandbox.rollback"),
+    rollback_token: set.body.execution.rollback_token,
+  });
+  assert.equal(rollback.status, 200);
+  assert.equal(rollback.body.operation, "prime.sandbox.rollback");
+  assert.equal(rollback.body.verification.valid, true);
+  assert.equal(sandbox.get("demo.signal"), undefined);
+
+  const replay = await post(base, "/api/v1/prime/rollback", {
+    ir: IR,
+    authorization: approval("prime.sandbox.rollback"),
+    rollback_token: set.body.execution.rollback_token,
+  });
+  assert.equal(replay.status, 400);
+  assert.match(replay.body.error, /already used/);
+});
+
+test("endpoint blocks requests when authentication middleware denies access", async (t) => {
+  const { server, base } = await startApp({ authenticated: false });
+  t.after(() => server.close());
+  const result = await post(base, "/api/v1/prime/execute", {
+    ir: IR,
+    authorization: approval("prime.sandbox.set"),
+    key: "blocked",
+    value: "never-written",
+  });
+  assert.equal(result.status, 401);
+  assert.match(result.body.error, /Authentication required/);
+});
+
+test("wrong authorization scope fails closed before sandbox mutation", () => {
+  const sandbox = new PrimeSandbox();
+  assert.throws(
+    () => sandbox.set({ ir: IR, authorization: approval("prime.echo"), key: "x", value: "y" }),
+    /Authorization action must be prime.sandbox.set/,
+  );
+  assert.equal(sandbox.get("x"), undefined);
+});
+
+test("rollback refuses when state changed after the receipted mutation", () => {
+  const sandbox = new PrimeSandbox();
+  const set = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "x", value: "one" });
+  sandbox.values.set("x", "unreceipted-change");
+  assert.throws(
+    () => sandbox.rollback({ ir: IR, authorization: approval("prime.sandbox.rollback"), rollback_token: set.execution.rollback_token }),
+    /state changed after the receipted mutation/,
+  );
+});


### PR DESCRIPTION
## Summary

Adds the first reversible Prime tool consequence on top of the merged Prime → RIO bridge.

The new Express router exposes an authenticated write-scoped HTTP surface for:

```text
POST /api/v1/prime/execute
POST /api/v1/prime/rollback
```

The bounded tool mutates one process-local sandbox value, emits a native RIO receipt plus a single-use rollback token, then restores the prior state under a second explicit authorization and emits a second verified receipt.

## Flow

```text
Prime IR
→ authenticated write-scoped endpoint
→ explicit action-specific authorization
→ sandbox state mutation
→ native RIO receipt
→ rollback token
→ separately authorized rollback
→ rollback receipt
→ restored state
```

## Implementation

- adds `gateway/prime/sandbox.mjs`
- adds `gateway/routes/prime-runtime.mjs`
- uses the existing `requireScope("write")` middleware in the production router
- validates Prime IR before mutation
- requires unexpired approval scoped exactly to `prime.sandbox.set` or `prime.sandbox.rollback`
- limits keys and values to a bounded process-local sandbox
- hashes the written value instead of returning it inside the receipt
- emits native RIO five-hash receipts for both mutation and rollback
- issues single-use rollback tokens
- rejects rollback replay
- rejects rollback if state changed after the receipted mutation
- adds full HTTP-cycle tests using an isolated Express app
- extends `npm run test:prime`

## Acceptance checks

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- unauthenticated requests are blocked
- authenticated set returns 201 and a verified native receipt
- the sandbox value actually changes
- authorized rollback restores the prior state and emits a verified receipt
- rollback token replay fails closed
- wrong authorization scope cannot mutate state
- intervening unreceipted state change blocks rollback
- the original `prime.echo` bridge remains green

## Boundary

This PR implements and independently tests the authenticated Express router, but does not yet mount it into `gateway/server.mjs`. That final wiring remains a separate reviewed change because the active server has database-backed startup, replay middleware, rate limiting, and route-order concerns that should be integrated explicitly rather than hidden inside this slice.