### PR TITLE
feat(prime): wire reversible runtime into live API v1 gateway

### DIFF
--- a/.github/workflows/prime-runtime-bridge.yml
+++ b/.github/workflows/prime-runtime-bridge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     paths:
       - "gateway/prime/**"
-      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/routes/prime-runtime.mjs"
+      - "gateway/routes/spgm-api-v1-govern.mjs"
+      - "gateway/tests/prime-*.test.mjs"
       - "gateway/package.json"
       - ".github/workflows/prime-runtime-bridge.yml"
   push:
     branches: [main]
     paths:
       - "gateway/prime/**"
-      - "gateway/tests/prime-runtime-bridge.test.mjs"
+      - "gateway/routes/prime-runtime.mjs"
+      - "gateway/routes/spgm-api-v1-govern.mjs"
+      - "gateway/tests/prime-*.test.mjs"
       - "gateway/package.json"
       - ".github/workflows/prime-runtime-bridge.yml"
 
@@ -25,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: gateway/package-lock.json
       - run: npm ci

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/routes/spgm-api-v1-govern.mjs
+++ b/gateway/routes/spgm-api-v1-govern.mjs
@@ -1,16 +1,23 @@
 /**
- * SPG-M API v1 Govern Bridge Route
+ * API v1 pre-route bridge composition.
  *
- * Intercepts POST /api/v1/intents/:id/govern only when SPG-M review
- * metadata is present. Otherwise it passes through to the standard API v1
- * govern route.
+ * This router is mounted by gateway/server.mjs behind API-key/JWT auth and
+ * rate limiting, before the general API v1 router. It hosts narrow bridge
+ * surfaces that must run before the standard routes.
  */
 import { Router } from "express";
 import { requireScope } from "../security/api-auth.mjs";
 import { requireRole } from "../security/principals.mjs";
+import primeRuntimeRoutes from "./prime-runtime.mjs";
 import { handleSpgmGovernRequest } from "./spgm-govern.mjs";
 
 const router = Router();
+
+// Prime reversible runtime is therefore live at:
+// POST /api/v1/prime/execute
+// POST /api/v1/prime/rollback
+// Its own router applies requireScope("write") and action-specific approval.
+router.use(primeRuntimeRoutes);
 
 router.post("/intents/:id/govern", requireScope("write"), requireRole("proposer", "executor"), (req, res, next) => {
   try {

--- a/gateway/tests/prime-live-gateway-wiring.test.mjs
+++ b/gateway/tests/prime-live-gateway-wiring.test.mjs
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+
+import apiV1BridgeRoutes from "../routes/spgm-api-v1-govern.mjs";
+import { primeSandbox } from "../prime/sandbox.mjs";
+
+const IR = {
+  source_expression: "7 -> 8 -> 7",
+  lexicon_version: "prime-experimental-v0.1",
+  symbols: ["7", "8", "7"],
+  transitions: [
+    { origin: "7", destination: "8", direction: "OUTWARD_TO_BOUNDARY" },
+    { origin: "8", destination: "7", direction: "INWARD_FROM_BOUNDARY" },
+  ],
+  closed_path: true,
+};
+
+function approval(action) {
+  return {
+    decision: "approved",
+    action,
+    authorized_by: "human-live-wiring-test",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+  };
+}
+
+async function startApp({ authenticated = true } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (authenticated) {
+      req.authMethod = "jwt";
+      req.user = { sub: "I-1", role: "owner" };
+    } else {
+      req.authMethod = "none";
+    }
+    next();
+  });
+  app.use("/api/v1", apiV1BridgeRoutes);
+  const server = await new Promise((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  return { server, base: `http://127.0.0.1:${server.address().port}` };
+}
+
+async function post(base, path, body) {
+  const response = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+test("mounted API v1 bridge executes and rolls back the reversible Prime action", async (t) => {
+  const { server, base } = await startApp();
+  t.after(() => server.close());
+
+  const key = `live.${Date.now()}`;
+  const set = await post(base, "/api/v1/prime/execute", {
+    ir: IR,
+    authorization: approval("prime.sandbox.set"),
+    key,
+    value: "bounded consequence",
+  });
+
+  assert.equal(set.status, 201);
+  assert.equal(set.body.operation, "prime.sandbox.set");
+  assert.equal(set.body.verification.valid, true);
+  assert.equal(primeSandbox.get(key), "bounded consequence");
+
+  const rollback = await post(base, "/api/v1/prime/rollback", {
+    ir: IR,
+    authorization: approval("prime.sandbox.rollback"),
+    rollback_token: set.body.execution.rollback_token,
+  });
+
+  assert.equal(rollback.status, 200);
+  assert.equal(rollback.body.operation, "prime.sandbox.rollback");
+  assert.equal(rollback.body.verification.valid, true);
+  assert.equal(primeSandbox.get(key), undefined);
+});
+
+test("mounted API v1 bridge rejects unauthenticated Prime consequence", async (t) => {
+  const { server, base } = await startApp({ authenticated: false });
+  t.after(() => server.close());
+
+  const response = await post(base, "/api/v1/prime/execute", {
+    ir: IR,
+    authorization: approval("prime.sandbox.set"),
+    key: "blocked.signal",
+    value: "must not cross",
+  });
+
+  assert.equal(response.status, 401);
+  assert.match(response.body.error, /Authentication required/);
+});


### PR DESCRIPTION
## Summary

Wires the merged reversible Prime runtime into the active authenticated `/api/v1` gateway without duplicating server middleware.

The live routes become:

```text
POST /api/v1/prime/execute
POST /api/v1/prime/rollback
```

## Integration seam

`gateway/server.mjs` already mounts `spgm-api-v1-govern.mjs` behind:

- API-key/JWT authentication
- rate limiting
- the existing `/api/v1` route order

This PR composes the Prime runtime router into that already-mounted bridge router. The Prime router retains its own `requireScope("write")` check and action-specific authorization validation.

## End-to-end flow

```text
Prime IR
→ live /api/v1 gateway
→ JWT/API-key authentication
→ write scope
→ explicit prime.sandbox.set approval
→ reversible sandbox mutation
→ native verified RIO receipt
→ single-use rollback token
→ explicit prime.sandbox.rollback approval
→ restored prior state
→ second verified receipt
```

## Changes

- composes `prime-runtime.mjs` into the mounted API v1 bridge router
- adds a live route-composition contract test
- proves authenticated set + rollback through the mounted route
- proves unauthenticated mutation is rejected
- extends the combined Prime test command
- broadens CI path coverage
- moves Prime CI to Node 24
- closes stale echo-only PR #181 as superseded

## Acceptance

```bash
cd gateway
npm ci
npm run test:prime
```

## Boundary

The consequence remains process-local and reversible. After this wiring is merged, the next slice should replace the in-memory sandbox store with a persistent but isolated resource adapter while preserving the same authorization, receipt, rollback, and replay contracts.