### PR TITLE
feat(prime): persist isolated workspace state and rollback burn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ pids
 *.seed
 *.pid.lock
 *.bak
+.rio-prime-workspace/
 
 # Coverage
 coverage/

--- a/gateway/prime/PERSISTENT_WORKSPACE_V0_4.md
+++ b/gateway/prime/PERSISTENT_WORKSPACE_V0_4.md
@@ -1,0 +1,53 @@
+# Prime Persistent Workspace v0.4
+
+The Prime reversible runtime now stores bounded workspace state on disk instead of only in process memory.
+
+## Default location
+
+```text
+.rio-prime-workspace/prime-workspace-state.json
+```
+
+Override the root with:
+
+```bash
+PRIME_WORKSPACE_ROOT=/isolated/path
+```
+
+The runtime never accepts a path from the Prime request. Callers provide only a validated logical key and string value.
+
+## Persistence contract
+
+The workspace persists:
+
+- current logical key/value state;
+- rollback records;
+- rollback-token burn state.
+
+A fresh `PrimeSandbox` instance pointed at the same root can recover a receipted mutation and perform its authorized rollback. Once a rollback token is used, that burn survives restart.
+
+## Write behavior
+
+- the workspace root is created with owner-only directory permissions where supported;
+- the state file is written with owner-only file permissions where supported;
+- updates use temporary-file replacement followed by atomic rename;
+- state shape is versioned and validated on every read;
+- malformed state fails closed.
+
+## Preserved runtime contract
+
+```text
+Prime IR
+→ authenticated live API v1 route
+→ explicit action-scoped approval
+→ isolated persistent mutation
+→ native verified RIO receipt
+→ durable single-use rollback token
+→ separately authorized rollback
+→ restored persistent state
+→ second verified receipt
+```
+
+## Boundary
+
+This is an isolated local persistence adapter. It is not a general filesystem tool, does not expose arbitrary paths, does not write outside its declared workspace root, and does not yet provide multi-process locking or distributed storage semantics.

--- a/gateway/prime/sandbox.mjs
+++ b/gateway/prime/sandbox.mjs
@@ -8,6 +8,7 @@ import {
   verifyReceipt,
 } from "../receipts/receipts.mjs";
 import { validatePrimeIr } from "./bridge.mjs";
+import { PrimeWorkspaceStore } from "./workspace-store.mjs";
 
 const SET_ACTION = "prime.sandbox.set";
 const ROLLBACK_ACTION = "prime.sandbox.rollback";
@@ -46,7 +47,7 @@ function receiptFor({ action, ir, authorization, execution, rules }) {
     status: "allowed",
     risk_level: "LOW",
     requires_approval: true,
-    checks: { prime_ir_valid: true, bounded_action: action, reversible: true },
+    checks: { prime_ir_valid: true, bounded_action: action, reversible: true, persistent_workspace: true },
   };
   const authorizationRecord = {
     intent_id: intent.intent_id,
@@ -58,7 +59,7 @@ function receiptFor({ action, ir, authorization, execution, rules }) {
   const executionRecord = {
     intent_id: intent.intent_id,
     action,
-    connector: "prime-sandbox",
+    connector: "prime-workspace",
     timestamp,
     result: execution,
   };
@@ -71,8 +72,8 @@ function receiptFor({ action, ir, authorization, execution, rules }) {
     action,
     agent_id: intent.agent_id,
     authorized_by: authorization.authorized_by,
-    ingestion: { source: "prime", channel: "prime-sandbox", source_message_id: ir.source_expression, timestamp },
-    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-sandbox-v0.2" },
+    ingestion: { source: "prime", channel: "prime-workspace", source_message_id: ir.source_expression, timestamp },
+    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-workspace-v0.4" },
   });
   const verification = verifyReceipt(receipt);
   if (!verification.valid) throw new Error("Generated RIO receipt failed verification");
@@ -96,13 +97,12 @@ function responseFor({ status, operation, execution, artifacts }) {
 }
 
 export class PrimeSandbox {
-  constructor() {
-    this.values = new Map();
-    this.rollbacks = new Map();
+  constructor({ store = new PrimeWorkspaceStore() } = {}) {
+    this.store = store;
   }
 
   get(key) {
-    return this.values.get(key);
+    return this.store.get(key);
   }
 
   set({ ir, authorization, key, value }) {
@@ -114,44 +114,53 @@ export class PrimeSandbox {
     if (typeof value !== "string" || value.length > 4096) {
       throw new Error("Sandbox value must be a string up to 4096 characters");
     }
-    const hadPrevious = this.values.has(key);
-    const previousValue = this.values.get(key);
-    this.values.set(key, value);
+    const hadPrevious = this.store.has(key);
+    const previousValue = this.store.get(key);
+    this.store.setValue(key, value);
     const rollbackToken = randomUUID();
-    this.rollbacks.set(rollbackToken, { key, hadPrevious, previousValue, expectedHash: sha256(value), used: false });
+    this.store.createRollback(rollbackToken, {
+      key,
+      hadPrevious,
+      previousValue,
+      expectedHash: sha256(value),
+      used: false,
+      created_at: new Date().toISOString(),
+    });
     const execution = {
       status: "EXECUTED",
-      effect: "SANDBOX_SET",
+      effect: "WORKSPACE_SET",
       key,
       value_hash: sha256(value),
       reversible: true,
       rollback_token: rollbackToken,
+      persistent: true,
       external_side_effects: false,
     };
-    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SANDBOX_ONLY", "ROLLBACK_AVAILABLE"] });
+    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ISOLATED_WORKSPACE", "PERSISTED", "ROLLBACK_AVAILABLE"] });
     return responseFor({ status: "RETURNED", operation: SET_ACTION, execution, artifacts });
   }
 
   rollback({ ir, authorization, rollback_token }) {
     validatePrimeIr(ir);
     validateAuthorization(authorization, ROLLBACK_ACTION);
-    const record = this.rollbacks.get(rollback_token);
+    const record = this.store.getRollback(rollback_token);
     if (!record || record.used) throw new Error("Rollback token is invalid or already used");
-    if (sha256(this.values.get(record.key)) !== record.expectedHash) {
+    if (sha256(this.store.get(record.key)) !== record.expectedHash) {
       throw new Error("Sandbox state changed after the receipted mutation");
     }
-    if (record.hadPrevious) this.values.set(record.key, record.previousValue);
-    else this.values.delete(record.key);
-    record.used = true;
+    if (record.hadPrevious) this.store.setValue(record.key, record.previousValue);
+    else this.store.deleteValue(record.key);
+    this.store.markRollbackUsed(rollback_token);
     const execution = {
       status: "EXECUTED",
-      effect: "SANDBOX_ROLLBACK",
+      effect: "WORKSPACE_ROLLBACK",
       key: record.key,
       restored_previous_state: true,
       rollback_token,
+      persistent: true,
       external_side_effects: false,
     };
-    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "STATE_RESTORED"] });
+    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "PERSISTENT_STATE_VERIFIED", "STATE_RESTORED"] });
     return responseFor({ status: "RETURNED", operation: ROLLBACK_ACTION, execution, artifacts });
   }
 }

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -1,0 +1,75 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const STATE_FILE = "prime-workspace-state.json";
+
+function emptyState() {
+  return { version: 1, values: {}, rollbacks: {} };
+}
+
+export class PrimeWorkspaceStore {
+  constructor({ root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace" } = {}) {
+    this.root = resolve(root);
+    this.statePath = resolve(this.root, STATE_FILE);
+    mkdirSync(this.root, { recursive: true, mode: 0o700 });
+    if (!existsSync(this.statePath)) this.#write(emptyState());
+    this.#read();
+  }
+
+  #read() {
+    const parsed = JSON.parse(readFileSync(this.statePath, "utf8"));
+    if (parsed?.version !== 1 || typeof parsed.values !== "object" || typeof parsed.rollbacks !== "object") {
+      throw new Error("Prime workspace state is invalid");
+    }
+    return parsed;
+  }
+
+  #write(state) {
+    const tempPath = `${this.statePath}.tmp`;
+    writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    renameSync(tempPath, this.statePath);
+  }
+
+  get(key) {
+    const state = this.#read();
+    return Object.prototype.hasOwnProperty.call(state.values, key) ? state.values[key] : undefined;
+  }
+
+  has(key) {
+    const state = this.#read();
+    return Object.prototype.hasOwnProperty.call(state.values, key);
+  }
+
+  setValue(key, value) {
+    const state = this.#read();
+    state.values[key] = value;
+    this.#write(state);
+  }
+
+  deleteValue(key) {
+    const state = this.#read();
+    delete state.values[key];
+    this.#write(state);
+  }
+
+  createRollback(token, record) {
+    const state = this.#read();
+    state.rollbacks[token] = record;
+    this.#write(state);
+  }
+
+  getRollback(token) {
+    return this.#read().rollbacks[token] || null;
+  }
+
+  markRollbackUsed(token) {
+    const state = this.#read();
+    if (!state.rollbacks[token]) throw new Error("Rollback token is invalid or already used");
+    state.rollbacks[token].used = true;
+    this.#write(state);
+  }
+
+  snapshot() {
+    return structuredClone(this.#read());
+  }
+}

--- a/gateway/tests/prime-authenticated-sandbox.test.mjs
+++ b/gateway/tests/prime-authenticated-sandbox.test.mjs
@@ -1,9 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import express from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { createPrimeRuntimeRouter } from "../routes/prime-runtime.mjs";
 import { PrimeSandbox } from "../prime/sandbox.mjs";
+import { PrimeWorkspaceStore } from "../prime/workspace-store.mjs";
 
 const IR = {
   source_expression: "7 -> 8 -> 7",
@@ -25,8 +29,14 @@ function approval(action) {
   };
 }
 
-async function startApp({ authenticated = true } = {}) {
-  const sandbox = new PrimeSandbox();
+function workspace(t) {
+  const root = mkdtempSync(join(tmpdir(), "prime-workspace-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+async function startApp(t, { authenticated = true, root = workspace(t) } = {}) {
+  const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
   const requireWrite = authenticated
     ? (_req, _res, next) => next()
     : (_req, res) => res.status(401).json({ error: "Authentication required." });
@@ -36,7 +46,8 @@ async function startApp({ authenticated = true } = {}) {
   const server = await new Promise((resolve) => {
     const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
   });
-  return { sandbox, server, base: `http://127.0.0.1:${server.address().port}` };
+  t.after(() => server.close());
+  return { sandbox, server, base: `http://127.0.0.1:${server.address().port}`, root };
 }
 
 async function post(base, path, body) {
@@ -48,9 +59,8 @@ async function post(base, path, body) {
   return { status: response.status, body: await response.json() };
 }
 
-test("authenticated Prime sandbox set and rollback produce verified RIO receipts", async (t) => {
-  const { sandbox, server, base } = await startApp();
-  t.after(() => server.close());
+test("authenticated Prime workspace set and rollback produce verified RIO receipts", async (t) => {
+  const { sandbox, base } = await startApp(t);
 
   const set = await post(base, "/api/v1/prime/execute", {
     ir: IR,
@@ -60,6 +70,7 @@ test("authenticated Prime sandbox set and rollback produce verified RIO receipts
   });
   assert.equal(set.status, 201);
   assert.equal(set.body.operation, "prime.sandbox.set");
+  assert.equal(set.body.execution.persistent, true);
   assert.equal(set.body.verification.valid, true);
   assert.equal(sandbox.get("demo.signal"), "7 -> 8 -> 7");
 
@@ -82,9 +93,30 @@ test("authenticated Prime sandbox set and rollback produce verified RIO receipts
   assert.match(replay.body.error, /already used/);
 });
 
+test("workspace state and rollback capability survive a fresh sandbox instance", (t) => {
+  const root = workspace(t);
+  const first = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+  const set = first.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "durable.signal", value: "formed" });
+
+  const restarted = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+  assert.equal(restarted.get("durable.signal"), "formed");
+  const rollback = restarted.rollback({
+    ir: IR,
+    authorization: approval("prime.sandbox.rollback"),
+    rollback_token: set.execution.rollback_token,
+  });
+  assert.equal(rollback.verification.valid, true);
+  assert.equal(restarted.get("durable.signal"), undefined);
+
+  const restartedAgain = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+  assert.throws(
+    () => restartedAgain.rollback({ ir: IR, authorization: approval("prime.sandbox.rollback"), rollback_token: set.execution.rollback_token }),
+    /already used/,
+  );
+});
+
 test("endpoint blocks requests when authentication middleware denies access", async (t) => {
-  const { server, base } = await startApp({ authenticated: false });
-  t.after(() => server.close());
+  const { base } = await startApp(t, { authenticated: false });
   const result = await post(base, "/api/v1/prime/execute", {
     ir: IR,
     authorization: approval("prime.sandbox.set"),
@@ -95,8 +127,8 @@ test("endpoint blocks requests when authentication middleware denies access", as
   assert.match(result.body.error, /Authentication required/);
 });
 
-test("wrong authorization scope fails closed before sandbox mutation", () => {
-  const sandbox = new PrimeSandbox();
+test("wrong authorization scope fails closed before workspace mutation", (t) => {
+  const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root: workspace(t) }) });
   assert.throws(
     () => sandbox.set({ ir: IR, authorization: approval("prime.echo"), key: "x", value: "y" }),
     /Authorization action must be prime.sandbox.set/,
@@ -104,10 +136,10 @@ test("wrong authorization scope fails closed before sandbox mutation", () => {
   assert.equal(sandbox.get("x"), undefined);
 });
 
-test("rollback refuses when state changed after the receipted mutation", () => {
-  const sandbox = new PrimeSandbox();
+test("rollback refuses when persistent state changed after the receipted mutation", (t) => {
+  const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root: workspace(t) }) });
   const set = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "x", value: "one" });
-  sandbox.values.set("x", "unreceipted-change");
+  sandbox.store.setValue("x", "unreceipted-change");
   assert.throws(
     () => sandbox.rollback({ ir: IR, authorization: approval("prime.sandbox.rollback"), rollback_token: set.execution.rollback_token }),
     /state changed after the receipted mutation/,


### PR DESCRIPTION
## Summary

Replaces the process-local Prime sandbox state with a persistent isolated workspace adapter while preserving the live authenticated API, explicit authorization, native RIO receipt, rollback, and replay contracts.

## Flow

```text
Prime IR
→ authenticated live API v1 route
→ explicit action-scoped approval
→ isolated persistent mutation
→ native verified RIO receipt
→ durable single-use rollback token
→ fresh process instance
→ separately authorized rollback
→ restored persistent state
→ durable token burn
```

## Implementation

- adds `gateway/prime/workspace-store.mjs`
- stores values and rollback records in one versioned JSON state file
- uses a fixed filename inside a declared workspace root
- never accepts caller-controlled filesystem paths
- writes through a temporary file and atomic rename
- creates owner-only directory/file permissions where supported
- validates state shape on every read and fails closed on malformed state
- updates `PrimeSandbox` to use the persistent adapter
- records persistent workspace checks in native RIO receipts
- preserves action-specific authorization for set and rollback
- persists rollback-token burn state across restarts
- ignores the default local workspace directory in Git
- documents the runtime boundary

## Acceptance

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- authenticated set and rollback still emit verified receipts
- state survives a fresh `PrimeSandbox` instance
- an unused rollback token survives restart
- rollback restores the persisted prior state
- a used rollback token remains burned after another restart
- wrong authorization scope cannot mutate the workspace
- an intervening unreceipted persistent change blocks rollback
- unauthenticated HTTP requests remain blocked

## Boundary

This is isolated local persistence, not a general filesystem tool. It does not expose arbitrary paths and does not yet provide multi-process locking or distributed storage semantics.