### PR TITLE
feat(prime): enforce single-writer workspace transactions

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs tests/prime-workspace-concurrency.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/sandbox.mjs
+++ b/gateway/prime/sandbox.mjs
@@ -18,62 +18,24 @@ function sha256(value) {
 }
 
 function validateAuthorization(authorization, action, now = new Date()) {
-  if (!authorization || authorization.decision !== "approved") {
-    throw new Error("Explicit approved authorization is required");
-  }
-  if (authorization.action !== action) {
-    throw new Error(`Authorization action must be ${action}`);
-  }
-  if (!authorization.authorized_by) {
-    throw new Error("Authorization requires authorized_by");
-  }
+  if (!authorization || authorization.decision !== "approved") throw new Error("Explicit approved authorization is required");
+  if (authorization.action !== action) throw new Error(`Authorization action must be ${action}`);
+  if (!authorization.authorized_by) throw new Error("Authorization requires authorized_by");
   const expiry = new Date(authorization.expires_at);
-  if (!authorization.expires_at || Number.isNaN(expiry.getTime()) || expiry <= now) {
-    throw new Error("Authorization is expired or invalid");
-  }
+  if (!authorization.expires_at || Number.isNaN(expiry.getTime()) || expiry <= now) throw new Error("Authorization is expired or invalid");
 }
 
 function receiptFor({ action, ir, authorization, execution, rules }) {
   const timestamp = new Date().toISOString();
-  const intent = {
-    intent_id: randomUUID(),
-    action,
-    agent_id: "prime-compiler",
-    parameters: { source_expression: ir.source_expression, symbols: ir.symbols },
-    timestamp,
-  };
-  const governance = {
-    intent_id: intent.intent_id,
-    status: "allowed",
-    risk_level: "LOW",
-    requires_approval: true,
-    checks: { prime_ir_valid: true, bounded_action: action, reversible: true, persistent_workspace: true },
-  };
-  const authorizationRecord = {
-    intent_id: intent.intent_id,
-    decision: "approved",
-    authorized_by: authorization.authorized_by,
-    timestamp: authorization.timestamp || timestamp,
-    conditions: { action, expires_at: authorization.expires_at },
-  };
-  const executionRecord = {
-    intent_id: intent.intent_id,
-    action,
-    connector: "prime-workspace",
-    timestamp,
-    result: execution,
-  };
+  const intent = { intent_id: randomUUID(), action, agent_id: "prime-compiler", parameters: { source_expression: ir.source_expression, symbols: ir.symbols }, timestamp };
+  const governance = { intent_id: intent.intent_id, status: "allowed", risk_level: "LOW", requires_approval: true, checks: { prime_ir_valid: true, bounded_action: action, reversible: true, persistent_workspace: true, single_writer: true } };
+  const authorizationRecord = { intent_id: intent.intent_id, decision: "approved", authorized_by: authorization.authorized_by, timestamp: authorization.timestamp || timestamp, conditions: { action, expires_at: authorization.expires_at } };
+  const executionRecord = { intent_id: intent.intent_id, action, connector: "prime-workspace", timestamp, result: execution };
   const receipt = generateReceipt({
-    intent_hash: hashIntent(intent),
-    governance_hash: hashGovernance(governance),
-    authorization_hash: hashAuthorization(authorizationRecord),
-    execution_hash: hashExecution(executionRecord),
-    intent_id: intent.intent_id,
-    action,
-    agent_id: intent.agent_id,
-    authorized_by: authorization.authorized_by,
+    intent_hash: hashIntent(intent), governance_hash: hashGovernance(governance), authorization_hash: hashAuthorization(authorizationRecord), execution_hash: hashExecution(executionRecord),
+    intent_id: intent.intent_id, action, agent_id: intent.agent_id, authorized_by: authorization.authorized_by,
     ingestion: { source: "prime", channel: "prime-workspace", source_message_id: ir.source_expression, timestamp },
-    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-workspace-v0.4" },
+    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-workspace-v0.5" },
   });
   const verification = verifyReceipt(receipt);
   if (!verification.valid) throw new Error("Generated RIO receipt failed verification");
@@ -81,86 +43,31 @@ function receiptFor({ action, ir, authorization, execution, rules }) {
 }
 
 function responseFor({ status, operation, execution, artifacts }) {
-  return {
-    status,
-    operation,
-    execution,
-    runtime: {
-      intent: artifacts.intent,
-      governance: artifacts.governance,
-      authorization: artifacts.authorization,
-      execution: artifacts.execution,
-    },
-    receipt: artifacts.receipt,
-    verification: artifacts.verification,
-  };
+  return { status, operation, execution, runtime: { intent: artifacts.intent, governance: artifacts.governance, authorization: artifacts.authorization, execution: artifacts.execution }, receipt: artifacts.receipt, verification: artifacts.verification };
 }
 
 export class PrimeSandbox {
-  constructor({ store = new PrimeWorkspaceStore() } = {}) {
-    this.store = store;
-  }
-
-  get(key) {
-    return this.store.get(key);
-  }
+  constructor({ store = new PrimeWorkspaceStore() } = {}) { this.store = store; }
+  get(key) { return this.store.get(key); }
 
   set({ ir, authorization, key, value }) {
     validatePrimeIr(ir);
     validateAuthorization(authorization, SET_ACTION);
-    if (typeof key !== "string" || !/^[a-zA-Z0-9._-]{1,64}$/.test(key)) {
-      throw new Error("Sandbox key is invalid");
-    }
-    if (typeof value !== "string" || value.length > 4096) {
-      throw new Error("Sandbox value must be a string up to 4096 characters");
-    }
-    const hadPrevious = this.store.has(key);
-    const previousValue = this.store.get(key);
-    this.store.setValue(key, value);
+    if (typeof key !== "string" || !/^[a-zA-Z0-9._-]{1,64}$/.test(key)) throw new Error("Sandbox key is invalid");
+    if (typeof value !== "string" || value.length > 4096) throw new Error("Sandbox value must be a string up to 4096 characters");
     const rollbackToken = randomUUID();
-    this.store.createRollback(rollbackToken, {
-      key,
-      hadPrevious,
-      previousValue,
-      expectedHash: sha256(value),
-      used: false,
-      created_at: new Date().toISOString(),
-    });
-    const execution = {
-      status: "EXECUTED",
-      effect: "WORKSPACE_SET",
-      key,
-      value_hash: sha256(value),
-      reversible: true,
-      rollback_token: rollbackToken,
-      persistent: true,
-      external_side_effects: false,
-    };
-    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ISOLATED_WORKSPACE", "PERSISTED", "ROLLBACK_AVAILABLE"] });
+    this.store.atomicSetWithRollback({ key, value, token: rollbackToken, expectedHash: sha256(value), createdAt: new Date().toISOString() });
+    const execution = { status: "EXECUTED", effect: "WORKSPACE_SET", key, value_hash: sha256(value), reversible: true, rollback_token: rollbackToken, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", external_side_effects: false };
+    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ISOLATED_WORKSPACE", "SINGLE_WRITER_LOCK", "PERSISTED", "ROLLBACK_AVAILABLE"] });
     return responseFor({ status: "RETURNED", operation: SET_ACTION, execution, artifacts });
   }
 
   rollback({ ir, authorization, rollback_token }) {
     validatePrimeIr(ir);
     validateAuthorization(authorization, ROLLBACK_ACTION);
-    const record = this.store.getRollback(rollback_token);
-    if (!record || record.used) throw new Error("Rollback token is invalid or already used");
-    if (sha256(this.store.get(record.key)) !== record.expectedHash) {
-      throw new Error("Sandbox state changed after the receipted mutation");
-    }
-    if (record.hadPrevious) this.store.setValue(record.key, record.previousValue);
-    else this.store.deleteValue(record.key);
-    this.store.markRollbackUsed(rollback_token);
-    const execution = {
-      status: "EXECUTED",
-      effect: "WORKSPACE_ROLLBACK",
-      key: record.key,
-      restored_previous_state: true,
-      rollback_token,
-      persistent: true,
-      external_side_effects: false,
-    };
-    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ROLLBACK_TOKEN_VALID", "PERSISTENT_STATE_VERIFIED", "STATE_RESTORED"] });
+    const record = this.store.atomicRollback({ token: rollback_token, hashValue: sha256 });
+    const execution = { status: "EXECUTED", effect: "WORKSPACE_ROLLBACK", key: record.key, restored_previous_state: true, rollback_token, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", external_side_effects: false };
+    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SINGLE_WRITER_LOCK", "ROLLBACK_TOKEN_VALID", "PERSISTENT_STATE_VERIFIED", "STATE_RESTORED", "TOKEN_BURNED"] });
     return responseFor({ status: "RETURNED", operation: ROLLBACK_ACTION, execution, artifacts });
   }
 }

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -106,6 +106,12 @@ export class PrimeWorkspaceStore {
     return Object.prototype.hasOwnProperty.call(state.values, key) ? state.values[key] : undefined;
   }
 
+  setValue(key, value) {
+    this.transact((state) => {
+      state.values[key] = value;
+    });
+  }
+
   atomicSetWithRollback({ key, value, token, expectedHash, createdAt }) {
     return this.transact((state) => {
       const hadPrevious = Object.prototype.hasOwnProperty.call(state.values, key);

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -1,16 +1,39 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 
 const STATE_FILE = "prime-workspace-state.json";
+const LOCK_FILE = "prime-workspace-state.lock";
+const SLEEP_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 
 function emptyState() {
   return { version: 1, values: {}, rollbacks: {} };
 }
 
+function sleep(ms) {
+  Atomics.wait(SLEEP_ARRAY, 0, 0, ms);
+}
+
 export class PrimeWorkspaceStore {
-  constructor({ root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace" } = {}) {
+  constructor({
+    root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace",
+    lockTimeoutMs = 2000,
+    staleLockMs = 10000,
+  } = {}) {
     this.root = resolve(root);
     this.statePath = resolve(this.root, STATE_FILE);
+    this.lockPath = resolve(this.root, LOCK_FILE);
+    this.lockTimeoutMs = lockTimeoutMs;
+    this.staleLockMs = staleLockMs;
     mkdirSync(this.root, { recursive: true, mode: 0o700 });
     if (!existsSync(this.statePath)) this.#write(emptyState());
     this.#read();
@@ -18,16 +41,64 @@ export class PrimeWorkspaceStore {
 
   #read() {
     const parsed = JSON.parse(readFileSync(this.statePath, "utf8"));
-    if (parsed?.version !== 1 || typeof parsed.values !== "object" || typeof parsed.rollbacks !== "object") {
+    if (
+      parsed?.version !== 1 ||
+      !parsed.values || typeof parsed.values !== "object" || Array.isArray(parsed.values) ||
+      !parsed.rollbacks || typeof parsed.rollbacks !== "object" || Array.isArray(parsed.rollbacks)
+    ) {
       throw new Error("Prime workspace state is invalid");
     }
     return parsed;
   }
 
   #write(state) {
-    const tempPath = `${this.statePath}.tmp`;
+    const tempPath = `${this.statePath}.${process.pid}.tmp`;
     writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
     renameSync(tempPath, this.statePath);
+  }
+
+  #acquireLock() {
+    const deadline = Date.now() + this.lockTimeoutMs;
+    while (Date.now() <= deadline) {
+      try {
+        const fd = openSync(this.lockPath, "wx", 0o600);
+        writeFileSync(fd, JSON.stringify({ pid: process.pid, acquired_at: new Date().toISOString() }));
+        return fd;
+      } catch (error) {
+        if (error.code !== "EEXIST") throw error;
+        try {
+          if (Date.now() - statSync(this.lockPath).mtimeMs > this.staleLockMs) {
+            unlinkSync(this.lockPath);
+            continue;
+          }
+        } catch (statError) {
+          if (statError.code === "ENOENT") continue;
+          throw statError;
+        }
+        sleep(10);
+      }
+    }
+    throw new Error("Prime workspace is busy");
+  }
+
+  #releaseLock(fd) {
+    try { closeSync(fd); } finally {
+      try { unlinkSync(this.lockPath); } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+  }
+
+  transact(mutator) {
+    const fd = this.#acquireLock();
+    try {
+      const state = this.#read();
+      const result = mutator(state);
+      this.#write(state);
+      return result;
+    } finally {
+      this.#releaseLock(fd);
+    }
   }
 
   get(key) {
@@ -35,38 +106,36 @@ export class PrimeWorkspaceStore {
     return Object.prototype.hasOwnProperty.call(state.values, key) ? state.values[key] : undefined;
   }
 
-  has(key) {
-    const state = this.#read();
-    return Object.prototype.hasOwnProperty.call(state.values, key);
+  atomicSetWithRollback({ key, value, token, expectedHash, createdAt }) {
+    return this.transact((state) => {
+      const hadPrevious = Object.prototype.hasOwnProperty.call(state.values, key);
+      const previousValue = state.values[key];
+      state.values[key] = value;
+      state.rollbacks[token] = {
+        key,
+        hadPrevious,
+        previousValue,
+        expectedHash,
+        used: false,
+        created_at: createdAt,
+      };
+      return { hadPrevious, previousValue };
+    });
   }
 
-  setValue(key, value) {
-    const state = this.#read();
-    state.values[key] = value;
-    this.#write(state);
-  }
-
-  deleteValue(key) {
-    const state = this.#read();
-    delete state.values[key];
-    this.#write(state);
-  }
-
-  createRollback(token, record) {
-    const state = this.#read();
-    state.rollbacks[token] = record;
-    this.#write(state);
-  }
-
-  getRollback(token) {
-    return this.#read().rollbacks[token] || null;
-  }
-
-  markRollbackUsed(token) {
-    const state = this.#read();
-    if (!state.rollbacks[token]) throw new Error("Rollback token is invalid or already used");
-    state.rollbacks[token].used = true;
-    this.#write(state);
+  atomicRollback({ token, hashValue }) {
+    return this.transact((state) => {
+      const record = state.rollbacks[token];
+      if (!record || record.used) throw new Error("Rollback token is invalid or already used");
+      if (hashValue(state.values[record.key]) !== record.expectedHash) {
+        throw new Error("Sandbox state changed after the receipted mutation");
+      }
+      if (record.hadPrevious) state.values[record.key] = record.previousValue;
+      else delete state.values[record.key];
+      record.used = true;
+      record.used_at = new Date().toISOString();
+      return structuredClone(record);
+    });
   }
 
   snapshot() {

--- a/gateway/tests/prime-workspace-concurrency.test.mjs
+++ b/gateway/tests/prime-workspace-concurrency.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -63,14 +63,13 @@ test("two processes racing one rollback token produce exactly one winner", async
 test("an active lock fails closed instead of overwriting state", () => {
   const root = mkdtempSync(join(tmpdir(), "prime-lock-"));
   try {
-    const storeA = new PrimeWorkspaceStore({ root, lockTimeoutMs: 30, staleLockMs: 60_000 });
-    const lock = join(root, "prime-workspace-state.lock");
-    const { writeFileSync } = await import("node:fs");
-    writeFileSync(lock, "held", { flag: "wx" });
+    const store = new PrimeWorkspaceStore({ root, lockTimeoutMs: 30, staleLockMs: 60_000 });
+    writeFileSync(join(root, "prime-workspace-state.lock"), "held", { flag: "wx" });
     assert.throws(
-      () => storeA.atomicSetWithRollback({ key: "x", value: "y", token: "t", expectedHash: sha256("y"), createdAt: new Date().toISOString() }),
+      () => store.atomicSetWithRollback({ key: "x", value: "y", token: "t", expectedHash: sha256("y"), createdAt: new Date().toISOString() }),
       /workspace is busy/,
     );
+    assert.equal(store.get("x"), undefined);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/gateway/tests/prime-workspace-concurrency.test.mjs
+++ b/gateway/tests/prime-workspace-concurrency.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+
+import { PrimeWorkspaceStore } from "../prime/workspace-store.mjs";
+
+function sha256(value) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function runRollback(root, token) {
+  const moduleUrl = new URL("../prime/workspace-store.mjs", import.meta.url).href;
+  const code = `
+    import { createHash } from "node:crypto";
+    import { PrimeWorkspaceStore } from ${JSON.stringify(moduleUrl)};
+    const hash = value => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+    try {
+      const store = new PrimeWorkspaceStore({ root: process.argv[1], lockTimeoutMs: 3000 });
+      store.atomicRollback({ token: process.argv[2], hashValue: hash });
+      process.stdout.write("SUCCESS");
+    } catch (error) {
+      process.stdout.write("BLOCKED:" + error.message);
+    }
+  `;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, token], { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", chunk => { out += chunk; });
+    child.stderr.on("data", chunk => { err += chunk; });
+    child.on("error", reject);
+    child.on("close", code => code === 0 ? resolve(out) : reject(new Error(err || `child exited ${code}`)));
+  });
+}
+
+test("two processes racing one rollback token produce exactly one winner", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "prime-race-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const token = "race-token";
+  const store = new PrimeWorkspaceStore({ root });
+  store.atomicSetWithRollback({
+    key: "race.signal",
+    value: "current",
+    token,
+    expectedHash: sha256("current"),
+    createdAt: new Date().toISOString(),
+  });
+
+  const results = await Promise.all([runRollback(root, token), runRollback(root, token)]);
+  assert.equal(results.filter(result => result === "SUCCESS").length, 1);
+  assert.equal(results.filter(result => /invalid or already used/.test(result)).length, 1);
+
+  const recovered = new PrimeWorkspaceStore({ root });
+  assert.equal(recovered.get("race.signal"), undefined);
+  assert.equal(recovered.snapshot().rollbacks[token].used, true);
+});
+
+test("an active lock fails closed instead of overwriting state", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-lock-"));
+  try {
+    const storeA = new PrimeWorkspaceStore({ root, lockTimeoutMs: 30, staleLockMs: 60_000 });
+    const lock = join(root, "prime-workspace-state.lock");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(lock, "held", { flag: "wx" });
+    assert.throws(
+      () => storeA.atomicSetWithRollback({ key: "x", value: "y", token: "t", expectedHash: sha256("y"), createdAt: new Date().toISOString() }),
+      /workspace is busy/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds concurrency integrity to the persistent Prime workspace so receipted mutations and rollback consumption are indivisible across processes.

## Flow

```text
Prime authorization
→ acquire exclusive workspace lock
→ read current persisted state
→ apply one complete mutation or rollback
→ atomically replace state file
→ release lock
→ emit verified RIO receipt
```

## Implementation

- adds an exclusive lock file acquired with create-if-absent semantics
- fails closed when an active writer holds the workspace
- supports bounded stale-lock recovery
- gives each atomic write a process-specific temporary path
- collapses set + rollback-record creation into one transaction
- collapses rollback verification + restoration + token burn into one transaction
- records `SINGLE_WRITER_LOCK` in governance checks and receipt policy rules
- preserves the existing authenticated API and persistent workspace contract

## Acceptance

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- two separate Node processes racing one rollback token produce exactly one winner
- the losing process receives `invalid or already used`
- restored state is correct after the race
- token burn remains persisted
- an active lock fails closed without changing workspace state
- all existing Prime runtime, authenticated route, persistence, receipt, and rollback tests remain green

## Boundary

This provides single-host, filesystem-backed concurrency integrity. It does not claim distributed consensus or network-filesystem locking semantics.