### PR TITLE
feat(prime): recover workspace after interrupted commit

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs tests/prime-workspace-concurrency.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs tests/prime-workspace-concurrency.test.mjs tests/prime-workspace-crash-recovery.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/CRASH_RECOVERY_V0_6.md
+++ b/gateway/prime/CRASH_RECOVERY_V0_6.md
@@ -1,0 +1,41 @@
+# Prime Workspace Crash Recovery v0.6
+
+The canonical workspace state file is the only committed state.
+
+## Commit point
+
+A transaction becomes committed only when its fully written and synchronized temporary state file is atomically renamed over `prime-workspace-state.json`.
+
+Therefore:
+
+- a process death before rename does not create a committed mutation;
+- an orphan temporary file is discarded during recovery;
+- recovery never promotes a temporary file based on apparent completeness;
+- no receipt or rollback capability is inferred for an interrupted transaction.
+
+## Lock recovery
+
+The workspace lock records the owning process ID and acquisition time.
+
+A lock may be reclaimed when:
+
+- its recorded process no longer exists on the host; or
+- its metadata is unreadable and the lock exceeds the configured stale-lock threshold.
+
+A lock owned by a live process is never reclaimed merely because time has passed.
+
+## Recovery sequence
+
+On workspace initialization:
+
+1. acquire or lawfully reclaim the exclusive lock;
+2. discard orphan transaction temporary files;
+3. create an empty canonical state only when no canonical state exists;
+4. validate the canonical state structure;
+5. release the lock.
+
+Malformed canonical state still fails closed. Recovery does not guess, merge, or reconstruct state from temporary files.
+
+## Boundary
+
+This is single-host crash recovery for an isolated filesystem workspace. It does not claim durability against storage-device failure, distributed consensus, or network-filesystem semantics.

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -1,9 +1,11 @@
 import {
   closeSync,
   existsSync,
+  fsyncSync,
   mkdirSync,
   openSync,
   readFileSync,
+  readdirSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -13,6 +15,8 @@ import { resolve } from "node:path";
 
 const STATE_FILE = "prime-workspace-state.json";
 const LOCK_FILE = "prime-workspace-state.lock";
+const TEMP_PREFIX = `${STATE_FILE}.`;
+const TEMP_SUFFIX = ".tmp";
 const SLEEP_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 
 function emptyState() {
@@ -23,20 +27,31 @@ function sleep(ms) {
   Atomics.wait(SLEEP_ARRAY, 0, 0, ms);
 }
 
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
 export class PrimeWorkspaceStore {
   constructor({
     root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace",
     lockTimeoutMs = 2000,
     staleLockMs = 10000,
+    faultInjector = null,
   } = {}) {
     this.root = resolve(root);
     this.statePath = resolve(this.root, STATE_FILE);
     this.lockPath = resolve(this.root, LOCK_FILE);
     this.lockTimeoutMs = lockTimeoutMs;
     this.staleLockMs = staleLockMs;
+    this.faultInjector = faultInjector;
     mkdirSync(this.root, { recursive: true, mode: 0o700 });
-    if (!existsSync(this.statePath)) this.#write(emptyState());
-    this.#read();
+    this.#recover();
   }
 
   #read() {
@@ -53,8 +68,35 @@ export class PrimeWorkspaceStore {
 
   #write(state) {
     const tempPath = `${this.statePath}.${process.pid}.tmp`;
-    writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    let fd;
+    try {
+      fd = openSync(tempPath, "w", 0o600);
+      writeFileSync(fd, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8" });
+      fsyncSync(fd);
+    } finally {
+      if (fd !== undefined) closeSync(fd);
+    }
+    this.faultInjector?.("after_temp_fsync", { tempPath, statePath: this.statePath });
     renameSync(tempPath, this.statePath);
+  }
+
+  #readLockOwner() {
+    try {
+      const parsed = JSON.parse(readFileSync(this.lockPath, "utf8"));
+      return {
+        pid: Number(parsed?.pid),
+        acquiredAt: parsed?.acquired_at || null,
+      };
+    } catch {
+      return { pid: null, acquiredAt: null };
+    }
+  }
+
+  #lockCanBeReclaimed() {
+    const owner = this.#readLockOwner();
+    if (owner.pid && !processIsAlive(owner.pid)) return true;
+    if (owner.pid && processIsAlive(owner.pid)) return false;
+    return Date.now() - statSync(this.lockPath).mtimeMs > this.staleLockMs;
   }
 
   #acquireLock() {
@@ -63,17 +105,18 @@ export class PrimeWorkspaceStore {
       try {
         const fd = openSync(this.lockPath, "wx", 0o600);
         writeFileSync(fd, JSON.stringify({ pid: process.pid, acquired_at: new Date().toISOString() }));
+        fsyncSync(fd);
         return fd;
       } catch (error) {
         if (error.code !== "EEXIST") throw error;
         try {
-          if (Date.now() - statSync(this.lockPath).mtimeMs > this.staleLockMs) {
+          if (this.#lockCanBeReclaimed()) {
             unlinkSync(this.lockPath);
             continue;
           }
-        } catch (statError) {
-          if (statError.code === "ENOENT") continue;
-          throw statError;
+        } catch (lockError) {
+          if (lockError.code === "ENOENT") continue;
+          throw lockError;
         }
         sleep(10);
       }
@@ -86,6 +129,24 @@ export class PrimeWorkspaceStore {
       try { unlinkSync(this.lockPath); } catch (error) {
         if (error.code !== "ENOENT") throw error;
       }
+    }
+  }
+
+  #discardOrphanTemps() {
+    for (const name of readdirSync(this.root)) {
+      if (!name.startsWith(TEMP_PREFIX) || !name.endsWith(TEMP_SUFFIX)) continue;
+      unlinkSync(resolve(this.root, name));
+    }
+  }
+
+  #recover() {
+    const fd = this.#acquireLock();
+    try {
+      this.#discardOrphanTemps();
+      if (!existsSync(this.statePath)) this.#write(emptyState());
+      this.#read();
+    } finally {
+      this.#releaseLock(fd);
     }
   }
 

--- a/gateway/tests/prime-workspace-crash-recovery.test.mjs
+++ b/gateway/tests/prime-workspace-crash-recovery.test.mjs
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+
+import { PrimeWorkspaceStore } from "../prime/workspace-store.mjs";
+
+function sha256(value) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function runChild(code, args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", code, ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", chunk => { stdout += chunk; });
+    child.stderr.on("data", chunk => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", exitCode => resolve({ exitCode, stdout, stderr }));
+  });
+}
+
+function moduleUrl() {
+  return new URL("../prime/workspace-store.mjs", import.meta.url).href;
+}
+
+test("dead process lock is reclaimed without changing canonical state", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "prime-crash-lock-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const original = new PrimeWorkspaceStore({ root });
+  original.setValue("signal", "before");
+
+  const code = `
+    import { PrimeWorkspaceStore } from ${JSON.stringify(moduleUrl())};
+    const store = new PrimeWorkspaceStore({ root: process.argv[1], staleLockMs: 60000 });
+    store.transact(() => process.exit(91));
+  `;
+  const crashed = await runChild(code, [root]);
+  assert.equal(crashed.exitCode, 91);
+
+  const recovered = new PrimeWorkspaceStore({ root, staleLockMs: 60000 });
+  assert.equal(recovered.get("signal"), "before");
+  assert.equal(readdirSync(root).includes("prime-workspace-state.lock"), false);
+});
+
+test("crash after temp fsync keeps canonical state and discards orphan temp", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "prime-crash-temp-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const original = new PrimeWorkspaceStore({ root });
+  original.setValue("signal", "before");
+
+  const code = `
+    import { createHash } from "node:crypto";
+    import { PrimeWorkspaceStore } from ${JSON.stringify(moduleUrl())};
+    const hash = value => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+    const store = new PrimeWorkspaceStore({
+      root: process.argv[1],
+      staleLockMs: 60000,
+      faultInjector(point) {
+        if (point === "after_temp_fsync") process.exit(92);
+      },
+    });
+    store.atomicSetWithRollback({
+      key: "signal",
+      value: "after",
+      token: "crash-token",
+      expectedHash: hash("after"),
+      createdAt: new Date().toISOString(),
+    });
+  `;
+  const crashed = await runChild(code, [root]);
+  assert.equal(crashed.exitCode, 92);
+
+  const recovered = new PrimeWorkspaceStore({ root, staleLockMs: 60000 });
+  assert.equal(recovered.get("signal"), "before");
+  assert.equal(recovered.snapshot().rollbacks["crash-token"], undefined);
+  assert.equal(readdirSync(root).some(name => name.endsWith(".tmp")), false);
+});
+
+test("successful commit remains rollback-capable after recovery path", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-crash-control-"));
+  try {
+    const store = new PrimeWorkspaceStore({ root });
+    store.atomicSetWithRollback({
+      key: "signal",
+      value: "after",
+      token: "control-token",
+      expectedHash: sha256("after"),
+      createdAt: new Date().toISOString(),
+    });
+    const recovered = new PrimeWorkspaceStore({ root });
+    assert.equal(recovered.get("signal"), "after");
+    assert.equal(recovered.snapshot().rollbacks["control-token"].used, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds crash integrity to the persistent Prime workspace by defining and testing the canonical commit point.

## Commit rule

```text
write candidate temp state
→ fsync candidate
→ atomic rename over canonical state
```

Only the rename commits the transaction. A process death before rename leaves the previous canonical state authoritative.

## Recovery flow

```text
workspace start
→ acquire or reclaim dead-owner lock
→ discard orphan temp files
→ validate canonical state
→ resume from last committed state
```

## Implementation

- records and synchronizes lock-owner metadata
- reclaims a lock immediately when its recorded process no longer exists
- never reclaims a lock owned by a live process merely because time elapsed
- writes candidate state through an owner-only file and `fsync`
- keeps atomic rename as the sole commit point
- discards orphan transaction temp files during initialization
- never promotes an orphan temp file
- preserves fail-closed behavior for malformed canonical state
- adds a bounded fault-injection seam for deterministic crash tests
- documents the recovery and non-claims boundary

## Acceptance

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- a child process can die while holding the workspace lock
- the next process reclaims that dead-owner lock
- canonical state remains unchanged after the interrupted transaction
- a child process can die after temp-file `fsync` but before rename
- the orphan candidate is discarded
- no rollback record is created for the uncommitted attempt
- successful committed state remains persistent and rollback-capable
- all existing Prime runtime, authentication, persistence, receipt, rollback, and concurrency tests remain green

## Boundary

This is single-host filesystem crash recovery. It does not claim storage-device durability, distributed consensus, or network-filesystem semantics.