### PR TITLE
feat(prime): atomically bind workspace consequence to durable receipt

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,7 @@
     "test:spgm:policy-review": "node --test tests/spgm-policy-review.test.mjs",
     "test:spgm:govern": "node --test tests/spgm-govern-request.test.mjs tests/spgm-govern-route.test.mjs",
     "test:spgm:openapi": "node --test tests/openapi-spgm.test.mjs",
-    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs tests/prime-workspace-concurrency.test.mjs tests/prime-workspace-crash-recovery.test.mjs"
+    "test:prime": "node --test tests/prime-runtime-bridge.test.mjs tests/prime-authenticated-sandbox.test.mjs tests/prime-live-gateway-wiring.test.mjs tests/prime-workspace-concurrency.test.mjs tests/prime-workspace-crash-recovery.test.mjs tests/prime-receipt-durability.test.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/gateway/prime/sandbox.mjs
+++ b/gateway/prime/sandbox.mjs
@@ -28,22 +28,44 @@ function validateAuthorization(authorization, action, now = new Date()) {
 function receiptFor({ action, ir, authorization, execution, rules }) {
   const timestamp = new Date().toISOString();
   const intent = { intent_id: randomUUID(), action, agent_id: "prime-compiler", parameters: { source_expression: ir.source_expression, symbols: ir.symbols }, timestamp };
-  const governance = { intent_id: intent.intent_id, status: "allowed", risk_level: "LOW", requires_approval: true, checks: { prime_ir_valid: true, bounded_action: action, reversible: true, persistent_workspace: true, single_writer: true } };
+  const governance = { intent_id: intent.intent_id, status: "allowed", risk_level: "LOW", requires_approval: true, checks: { prime_ir_valid: true, bounded_action: action, reversible: true, persistent_workspace: true, single_writer: true, durable_proof_coupled: true } };
   const authorizationRecord = { intent_id: intent.intent_id, decision: "approved", authorized_by: authorization.authorized_by, timestamp: authorization.timestamp || timestamp, conditions: { action, expires_at: authorization.expires_at } };
   const executionRecord = { intent_id: intent.intent_id, action, connector: "prime-workspace", timestamp, result: execution };
   const receipt = generateReceipt({
     intent_hash: hashIntent(intent), governance_hash: hashGovernance(governance), authorization_hash: hashAuthorization(authorizationRecord), execution_hash: hashExecution(executionRecord),
     intent_id: intent.intent_id, action, agent_id: intent.agent_id, authorized_by: authorization.authorized_by,
     ingestion: { source: "prime", channel: "prime-workspace", source_message_id: ir.source_expression, timestamp },
-    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-workspace-v0.5" },
+    policy: { evaluated: true, decision: "ALLOW", rules_triggered: rules, policy_pack: "prime-workspace-v0.7" },
   });
   const verification = verifyReceipt(receipt);
   if (!verification.valid) throw new Error("Generated RIO receipt failed verification");
   return { intent, governance, authorization: authorizationRecord, execution: executionRecord, receipt, verification };
 }
 
-function responseFor({ status, operation, execution, artifacts }) {
-  return { status, operation, execution, runtime: { intent: artifacts.intent, governance: artifacts.governance, authorization: artifacts.authorization, execution: artifacts.execution }, receipt: artifacts.receipt, verification: artifacts.verification };
+function durableProof(artifacts, operation) {
+  return {
+    proof_id: artifacts.intent.intent_id,
+    operation,
+    receipt: artifacts.receipt,
+    verification: artifacts.verification,
+    runtime: {
+      intent: artifacts.intent,
+      governance: artifacts.governance,
+      authorization: artifacts.authorization,
+      execution: artifacts.execution,
+    },
+  };
+}
+
+function responseFor({ status, operation, execution, artifacts, revision }) {
+  return {
+    status,
+    operation,
+    execution: { ...execution, workspace_revision: revision, durable_proof_id: artifacts.intent.intent_id },
+    runtime: { intent: artifacts.intent, governance: artifacts.governance, authorization: artifacts.authorization, execution: artifacts.execution },
+    receipt: artifacts.receipt,
+    verification: artifacts.verification,
+  };
 }
 
 export class PrimeSandbox {
@@ -55,20 +77,37 @@ export class PrimeSandbox {
     validateAuthorization(authorization, SET_ACTION);
     if (typeof key !== "string" || !/^[a-zA-Z0-9._-]{1,64}$/.test(key)) throw new Error("Sandbox key is invalid");
     if (typeof value !== "string" || value.length > 4096) throw new Error("Sandbox value must be a string up to 4096 characters");
+
     const rollbackToken = randomUUID();
-    this.store.atomicSetWithRollback({ key, value, token: rollbackToken, expectedHash: sha256(value), createdAt: new Date().toISOString() });
-    const execution = { status: "EXECUTED", effect: "WORKSPACE_SET", key, value_hash: sha256(value), reversible: true, rollback_token: rollbackToken, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", external_side_effects: false };
-    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ISOLATED_WORKSPACE", "SINGLE_WRITER_LOCK", "PERSISTED", "ROLLBACK_AVAILABLE"] });
-    return responseFor({ status: "RETURNED", operation: SET_ACTION, execution, artifacts });
+    const execution = { status: "EXECUTED", effect: "WORKSPACE_SET", key, value_hash: sha256(value), reversible: true, rollback_token: rollbackToken, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", proof_persistence: "ATOMIC_WITH_STATE", external_side_effects: false };
+    const artifacts = receiptFor({ action: SET_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "ISOLATED_WORKSPACE", "SINGLE_WRITER_LOCK", "DURABLE_PROOF_COUPLED", "PERSISTED", "ROLLBACK_AVAILABLE"] });
+    const committed = this.store.atomicSetWithRollback({
+      key,
+      value,
+      token: rollbackToken,
+      expectedHash: sha256(value),
+      createdAt: new Date().toISOString(),
+      proof: durableProof(artifacts, SET_ACTION),
+    });
+    return responseFor({ status: "RETURNED", operation: SET_ACTION, execution, artifacts, revision: committed.revision });
   }
 
   rollback({ ir, authorization, rollback_token }) {
     validatePrimeIr(ir);
     validateAuthorization(authorization, ROLLBACK_ACTION);
-    const record = this.store.atomicRollback({ token: rollback_token, hashValue: sha256 });
-    const execution = { status: "EXECUTED", effect: "WORKSPACE_ROLLBACK", key: record.key, restored_previous_state: true, rollback_token, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", external_side_effects: false };
-    const artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SINGLE_WRITER_LOCK", "ROLLBACK_TOKEN_VALID", "PERSISTENT_STATE_VERIFIED", "STATE_RESTORED", "TOKEN_BURNED"] });
-    return responseFor({ status: "RETURNED", operation: ROLLBACK_ACTION, execution, artifacts });
+
+    let execution;
+    let artifacts;
+    const committed = this.store.atomicRollback({
+      token: rollback_token,
+      hashValue: sha256,
+      proofFactory: (record) => {
+        execution = { status: "EXECUTED", effect: "WORKSPACE_ROLLBACK", key: record.key, restored_previous_state: true, rollback_token, persistent: true, concurrency_control: "SINGLE_WRITER_LOCK", proof_persistence: "ATOMIC_WITH_STATE", external_side_effects: false };
+        artifacts = receiptFor({ action: ROLLBACK_ACTION, ir, authorization, execution, rules: ["PRIME_IR_VALID", "EXPLICIT_AUTHORIZATION", "SINGLE_WRITER_LOCK", "ROLLBACK_TOKEN_VALID", "DURABLE_PROOF_COUPLED", "PERSISTENT_STATE_VERIFIED", "STATE_RESTORED", "TOKEN_BURNED"] });
+        return durableProof(artifacts, ROLLBACK_ACTION);
+      },
+    });
+    return responseFor({ status: "RETURNED", operation: ROLLBACK_ACTION, execution, artifacts, revision: committed.revision });
   }
 }
 

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -44,12 +44,9 @@ function validateState(parsed) {
     !parsed.values || typeof parsed.values !== "object" || Array.isArray(parsed.values) ||
     !parsed.rollbacks || typeof parsed.rollbacks !== "object" || Array.isArray(parsed.rollbacks) ||
     !parsed.proofs || typeof parsed.proofs !== "object" || Array.isArray(parsed.proofs)
-  ) {
-    throw new Error("Prime workspace state is invalid");
-  }
-  if (parsed.revision === 0 && parsed.latest_proof_id !== null) {
-    throw new Error("Prime workspace proof linkage is invalid");
-  }
+  ) throw new Error("Prime workspace state is invalid");
+
+  if (parsed.revision === 0 && parsed.latest_proof_id !== null) throw new Error("Prime workspace proof linkage is invalid");
   if (parsed.revision > 0) {
     const latest = parsed.proofs[parsed.latest_proof_id];
     if (!latest || latest.revision !== parsed.revision || latest.proof_id !== parsed.latest_proof_id) {
@@ -60,12 +57,7 @@ function validateState(parsed) {
 }
 
 export class PrimeWorkspaceStore {
-  constructor({
-    root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace",
-    lockTimeoutMs = 2000,
-    staleLockMs = 10000,
-    faultInjector = null,
-  } = {}) {
+  constructor({ root = process.env.PRIME_WORKSPACE_ROOT || ".rio-prime-workspace", lockTimeoutMs = 2000, staleLockMs = 10000, faultInjector = null } = {}) {
     this.root = resolve(root);
     this.statePath = resolve(this.root, STATE_FILE);
     this.lockPath = resolve(this.root, LOCK_FILE);
@@ -121,10 +113,7 @@ export class PrimeWorkspaceStore {
       } catch (error) {
         if (error.code !== "EEXIST") throw error;
         try {
-          if (this.#lockCanBeReclaimed()) {
-            unlinkSync(this.lockPath);
-            continue;
-          }
+          if (this.#lockCanBeReclaimed()) { unlinkSync(this.lockPath); continue; }
         } catch (lockError) {
           if (lockError.code === "ENOENT") continue;
           throw lockError;
@@ -173,9 +162,7 @@ export class PrimeWorkspaceStore {
   }
 
   #attachProof(state, proof) {
-    if (!proof?.proof_id || !proof?.receipt || proof.verification?.valid !== true) {
-      throw new Error("A verified durable proof is required for workspace commit");
-    }
+    if (!proof?.proof_id || !proof?.receipt || proof.verification?.valid !== true) throw new Error("A verified durable proof is required for workspace commit");
     if (state.proofs[proof.proof_id]) throw new Error("Durable proof identifier already exists");
     const revision = state.revision + 1;
     state.proofs[proof.proof_id] = { ...structuredClone(proof), revision };
@@ -194,12 +181,9 @@ export class PrimeWorkspaceStore {
     return proof ? structuredClone(proof) : null;
   }
 
+  // Explicit test/tamper seam: bypasses governed revision/proof creation so rollback mismatch checks can be exercised.
   setValue(key, value) {
-    this.transact((state) => {
-      state.values[key] = value;
-      state.revision += 1;
-      state.latest_proof_id = "UNRECEIPTED_MUTATION";
-    });
+    this.transact((state) => { state.values[key] = value; });
   }
 
   atomicSetWithRollback({ key, value, token, expectedHash, createdAt, proof }) {
@@ -207,15 +191,7 @@ export class PrimeWorkspaceStore {
       const hadPrevious = Object.prototype.hasOwnProperty.call(state.values, key);
       const previousValue = state.values[key];
       state.values[key] = value;
-      state.rollbacks[token] = {
-        key,
-        hadPrevious,
-        previousValue,
-        expectedHash,
-        used: false,
-        created_at: createdAt,
-        set_proof_id: proof.proof_id,
-      };
+      state.rollbacks[token] = { key, hadPrevious, previousValue, expectedHash, used: false, created_at: createdAt, set_proof_id: proof.proof_id };
       const revision = this.#attachProof(state, proof);
       return { hadPrevious, previousValue, revision };
     });
@@ -225,9 +201,7 @@ export class PrimeWorkspaceStore {
     return this.transact((state) => {
       const record = state.rollbacks[token];
       if (!record || record.used) throw new Error("Rollback token is invalid or already used");
-      if (hashValue(state.values[record.key]) !== record.expectedHash) {
-        throw new Error("Sandbox state changed after the receipted mutation");
-      }
+      if (hashValue(state.values[record.key]) !== record.expectedHash) throw new Error("Sandbox state changed after the receipted mutation");
       const proof = proofFactory(structuredClone(record));
       if (record.hadPrevious) state.values[record.key] = record.previousValue;
       else delete state.values[record.key];

--- a/gateway/prime/workspace-store.mjs
+++ b/gateway/prime/workspace-store.mjs
@@ -20,7 +20,7 @@ const TEMP_SUFFIX = ".tmp";
 const SLEEP_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 
 function emptyState() {
-  return { version: 1, values: {}, rollbacks: {} };
+  return { version: 2, revision: 0, latest_proof_id: null, values: {}, rollbacks: {}, proofs: {} };
 }
 
 function sleep(ms) {
@@ -35,6 +35,28 @@ function processIsAlive(pid) {
   } catch (error) {
     return error.code === "EPERM";
   }
+}
+
+function validateState(parsed) {
+  if (
+    parsed?.version !== 2 ||
+    !Number.isInteger(parsed.revision) || parsed.revision < 0 ||
+    !parsed.values || typeof parsed.values !== "object" || Array.isArray(parsed.values) ||
+    !parsed.rollbacks || typeof parsed.rollbacks !== "object" || Array.isArray(parsed.rollbacks) ||
+    !parsed.proofs || typeof parsed.proofs !== "object" || Array.isArray(parsed.proofs)
+  ) {
+    throw new Error("Prime workspace state is invalid");
+  }
+  if (parsed.revision === 0 && parsed.latest_proof_id !== null) {
+    throw new Error("Prime workspace proof linkage is invalid");
+  }
+  if (parsed.revision > 0) {
+    const latest = parsed.proofs[parsed.latest_proof_id];
+    if (!latest || latest.revision !== parsed.revision || latest.proof_id !== parsed.latest_proof_id) {
+      throw new Error("Prime workspace committed state is missing durable proof");
+    }
+  }
+  return parsed;
 }
 
 export class PrimeWorkspaceStore {
@@ -55,15 +77,7 @@ export class PrimeWorkspaceStore {
   }
 
   #read() {
-    const parsed = JSON.parse(readFileSync(this.statePath, "utf8"));
-    if (
-      parsed?.version !== 1 ||
-      !parsed.values || typeof parsed.values !== "object" || Array.isArray(parsed.values) ||
-      !parsed.rollbacks || typeof parsed.rollbacks !== "object" || Array.isArray(parsed.rollbacks)
-    ) {
-      throw new Error("Prime workspace state is invalid");
-    }
-    return parsed;
+    return validateState(JSON.parse(readFileSync(this.statePath, "utf8")));
   }
 
   #write(state) {
@@ -83,10 +97,7 @@ export class PrimeWorkspaceStore {
   #readLockOwner() {
     try {
       const parsed = JSON.parse(readFileSync(this.lockPath, "utf8"));
-      return {
-        pid: Number(parsed?.pid),
-        acquiredAt: parsed?.acquired_at || null,
-      };
+      return { pid: Number(parsed?.pid), acquiredAt: parsed?.acquired_at || null };
     } catch {
       return { pid: null, acquiredAt: null };
     }
@@ -134,8 +145,7 @@ export class PrimeWorkspaceStore {
 
   #discardOrphanTemps() {
     for (const name of readdirSync(this.root)) {
-      if (!name.startsWith(TEMP_PREFIX) || !name.endsWith(TEMP_SUFFIX)) continue;
-      unlinkSync(resolve(this.root, name));
+      if (name.startsWith(TEMP_PREFIX) && name.endsWith(TEMP_SUFFIX)) unlinkSync(resolve(this.root, name));
     }
   }
 
@@ -162,18 +172,37 @@ export class PrimeWorkspaceStore {
     }
   }
 
+  #attachProof(state, proof) {
+    if (!proof?.proof_id || !proof?.receipt || proof.verification?.valid !== true) {
+      throw new Error("A verified durable proof is required for workspace commit");
+    }
+    if (state.proofs[proof.proof_id]) throw new Error("Durable proof identifier already exists");
+    const revision = state.revision + 1;
+    state.proofs[proof.proof_id] = { ...structuredClone(proof), revision };
+    state.revision = revision;
+    state.latest_proof_id = proof.proof_id;
+    return revision;
+  }
+
   get(key) {
     const state = this.#read();
     return Object.prototype.hasOwnProperty.call(state.values, key) ? state.values[key] : undefined;
   }
 
+  getProof(proofId) {
+    const proof = this.#read().proofs[proofId];
+    return proof ? structuredClone(proof) : null;
+  }
+
   setValue(key, value) {
     this.transact((state) => {
       state.values[key] = value;
+      state.revision += 1;
+      state.latest_proof_id = "UNRECEIPTED_MUTATION";
     });
   }
 
-  atomicSetWithRollback({ key, value, token, expectedHash, createdAt }) {
+  atomicSetWithRollback({ key, value, token, expectedHash, createdAt, proof }) {
     return this.transact((state) => {
       const hadPrevious = Object.prototype.hasOwnProperty.call(state.values, key);
       const previousValue = state.values[key];
@@ -185,23 +214,28 @@ export class PrimeWorkspaceStore {
         expectedHash,
         used: false,
         created_at: createdAt,
+        set_proof_id: proof.proof_id,
       };
-      return { hadPrevious, previousValue };
+      const revision = this.#attachProof(state, proof);
+      return { hadPrevious, previousValue, revision };
     });
   }
 
-  atomicRollback({ token, hashValue }) {
+  atomicRollback({ token, hashValue, proofFactory }) {
     return this.transact((state) => {
       const record = state.rollbacks[token];
       if (!record || record.used) throw new Error("Rollback token is invalid or already used");
       if (hashValue(state.values[record.key]) !== record.expectedHash) {
         throw new Error("Sandbox state changed after the receipted mutation");
       }
+      const proof = proofFactory(structuredClone(record));
       if (record.hadPrevious) state.values[record.key] = record.previousValue;
       else delete state.values[record.key];
       record.used = true;
       record.used_at = new Date().toISOString();
-      return structuredClone(record);
+      record.rollback_proof_id = proof.proof_id;
+      const revision = this.#attachProof(state, proof);
+      return { record: structuredClone(record), proof: structuredClone(proof), revision };
     });
   }
 

--- a/gateway/tests/prime-receipt-durability.test.mjs
+++ b/gateway/tests/prime-receipt-durability.test.mjs
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PrimeSandbox } from "../prime/sandbox.mjs";
+import { PrimeWorkspaceStore } from "../prime/workspace-store.mjs";
+
+const IR = {
+  source_expression: "7 -> 8 -> 7",
+  lexicon_version: "prime-experimental-v0.1",
+  symbols: ["7", "8", "7"],
+  transitions: [
+    { origin: "7", destination: "8", direction: "OUTWARD_TO_BOUNDARY" },
+    { origin: "8", destination: "7", direction: "INWARD_FROM_BOUNDARY" },
+  ],
+  closed_path: true,
+};
+
+function approval(action) {
+  return { decision: "approved", action, authorized_by: "human-test-authority", expires_at: new Date(Date.now() + 60_000).toISOString() };
+}
+
+test("returned receipt is the exact proof atomically persisted with committed state", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-proof-coupling-"));
+  try {
+    const store = new PrimeWorkspaceStore({ root });
+    const sandbox = new PrimeSandbox({ store });
+    const result = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "proof.signal", value: "committed" });
+
+    const proof = store.getProof(result.execution.durable_proof_id);
+    assert.ok(proof);
+    assert.deepEqual(proof.receipt, result.receipt);
+    assert.deepEqual(proof.verification, result.verification);
+    assert.equal(proof.revision, result.execution.workspace_revision);
+    assert.equal(store.get("proof.signal"), "committed");
+    assert.equal(store.snapshot().latest_proof_id, result.execution.durable_proof_id);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("set and rollback each advance one proof-bound workspace revision", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-proof-revisions-"));
+  try {
+    const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+    const set = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "proof.signal", value: "current" });
+    const rollback = sandbox.rollback({ ir: IR, authorization: approval("prime.sandbox.rollback"), rollback_token: set.execution.rollback_token });
+
+    const recovered = new PrimeWorkspaceStore({ root });
+    const state = recovered.snapshot();
+    assert.equal(state.revision, 2);
+    assert.equal(state.latest_proof_id, rollback.execution.durable_proof_id);
+    assert.deepEqual(state.proofs[set.execution.durable_proof_id].receipt, set.receipt);
+    assert.deepEqual(state.proofs[rollback.execution.durable_proof_id].receipt, rollback.receipt);
+    assert.equal(state.rollbacks[set.execution.rollback_token].rollback_proof_id, rollback.execution.durable_proof_id);
+    assert.equal(recovered.get("proof.signal"), undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("canonical state without its declared durable proof fails closed on recovery", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-proof-torn-state-"));
+  try {
+    const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+    const result = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "proof.signal", value: "committed" });
+    const path = join(root, "prime-workspace-state.json");
+    const state = JSON.parse(readFileSync(path, "utf8"));
+    delete state.proofs[result.execution.durable_proof_id];
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+
+    assert.throws(() => new PrimeWorkspaceStore({ root }), /missing durable proof/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("proof record claiming a different revision fails closed on recovery", () => {
+  const root = mkdtempSync(join(tmpdir(), "prime-proof-torn-proof-"));
+  try {
+    const sandbox = new PrimeSandbox({ store: new PrimeWorkspaceStore({ root }) });
+    const result = sandbox.set({ ir: IR, authorization: approval("prime.sandbox.set"), key: "proof.signal", value: "committed" });
+    const path = join(root, "prime-workspace-state.json");
+    const state = JSON.parse(readFileSync(path, "utf8"));
+    state.proofs[result.execution.durable_proof_id].revision = 999;
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+
+    assert.throws(() => new PrimeWorkspaceStore({ root }), /missing durable proof/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/gateway/tests/prime-workspace-concurrency.test.mjs
+++ b/gateway/tests/prime-workspace-concurrency.test.mjs
@@ -12,7 +12,11 @@ function sha256(value) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
 
-function runRollback(root, token) {
+function proof(id, operation = "test") {
+  return { proof_id: id, operation, receipt: { receipt_id: id }, verification: { valid: true }, runtime: {} };
+}
+
+function runRollback(root, token, proofId) {
   const moduleUrl = new URL("../prime/workspace-store.mjs", import.meta.url).href;
   const code = `
     import { createHash } from "node:crypto";
@@ -20,14 +24,18 @@ function runRollback(root, token) {
     const hash = value => createHash("sha256").update(JSON.stringify(value)).digest("hex");
     try {
       const store = new PrimeWorkspaceStore({ root: process.argv[1], lockTimeoutMs: 3000 });
-      store.atomicRollback({ token: process.argv[2], hashValue: hash });
+      store.atomicRollback({
+        token: process.argv[2],
+        hashValue: hash,
+        proofFactory: () => ({ proof_id: process.argv[3], operation: "rollback", receipt: { receipt_id: process.argv[3] }, verification: { valid: true }, runtime: {} }),
+      });
       process.stdout.write("SUCCESS");
     } catch (error) {
       process.stdout.write("BLOCKED:" + error.message);
     }
   `;
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, token], { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, token, proofId], { stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     let err = "";
     child.stdout.on("data", chunk => { out += chunk; });
@@ -43,21 +51,16 @@ test("two processes racing one rollback token produce exactly one winner", async
 
   const token = "race-token";
   const store = new PrimeWorkspaceStore({ root });
-  store.atomicSetWithRollback({
-    key: "race.signal",
-    value: "current",
-    token,
-    expectedHash: sha256("current"),
-    createdAt: new Date().toISOString(),
-  });
+  store.atomicSetWithRollback({ key: "race.signal", value: "current", token, expectedHash: sha256("current"), createdAt: new Date().toISOString(), proof: proof("set-proof", "set") });
 
-  const results = await Promise.all([runRollback(root, token), runRollback(root, token)]);
+  const results = await Promise.all([runRollback(root, token, "rollback-proof-a"), runRollback(root, token, "rollback-proof-b")]);
   assert.equal(results.filter(result => result === "SUCCESS").length, 1);
   assert.equal(results.filter(result => /invalid or already used/.test(result)).length, 1);
 
   const recovered = new PrimeWorkspaceStore({ root });
   assert.equal(recovered.get("race.signal"), undefined);
   assert.equal(recovered.snapshot().rollbacks[token].used, true);
+  assert.equal(recovered.snapshot().revision, 2);
 });
 
 test("an active lock fails closed instead of overwriting state", () => {
@@ -66,7 +69,7 @@ test("an active lock fails closed instead of overwriting state", () => {
     const store = new PrimeWorkspaceStore({ root, lockTimeoutMs: 30, staleLockMs: 60_000 });
     writeFileSync(join(root, "prime-workspace-state.lock"), "held", { flag: "wx" });
     assert.throws(
-      () => store.atomicSetWithRollback({ key: "x", value: "y", token: "t", expectedHash: sha256("y"), createdAt: new Date().toISOString() }),
+      () => store.atomicSetWithRollback({ key: "x", value: "y", token: "t", expectedHash: sha256("y"), createdAt: new Date().toISOString(), proof: proof("blocked-proof") }),
       /workspace is busy/,
     );
     assert.equal(store.get("x"), undefined);

--- a/gateway/tests/prime-workspace-crash-recovery.test.mjs
+++ b/gateway/tests/prime-workspace-crash-recovery.test.mjs
@@ -12,11 +12,13 @@ function sha256(value) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
 
+function proof(id, operation = "test") {
+  return { proof_id: id, operation, receipt: { receipt_id: id }, verification: { valid: true }, runtime: {} };
+}
+
 function runChild(code, args = []) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--input-type=module", "-e", code, ...args], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawn(process.execPath, ["--input-type=module", "-e", code, ...args], { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", chunk => { stdout += chunk; });
@@ -33,10 +35,8 @@ function moduleUrl() {
 test("dead process lock is reclaimed without changing canonical state", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "prime-crash-lock-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
-
   const original = new PrimeWorkspaceStore({ root });
   original.setValue("signal", "before");
-
   const code = `
     import { PrimeWorkspaceStore } from ${JSON.stringify(moduleUrl())};
     const store = new PrimeWorkspaceStore({ root: process.argv[1], staleLockMs: 60000 });
@@ -44,7 +44,6 @@ test("dead process lock is reclaimed without changing canonical state", async (t
   `;
   const crashed = await runChild(code, [root]);
   assert.equal(crashed.exitCode, 91);
-
   const recovered = new PrimeWorkspaceStore({ root, staleLockMs: 60000 });
   assert.equal(recovered.get("signal"), "before");
   assert.equal(readdirSync(root).includes("prime-workspace-state.lock"), false);
@@ -53,35 +52,27 @@ test("dead process lock is reclaimed without changing canonical state", async (t
 test("crash after temp fsync keeps canonical state and discards orphan temp", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "prime-crash-temp-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
-
   const original = new PrimeWorkspaceStore({ root });
   original.setValue("signal", "before");
-
   const code = `
     import { createHash } from "node:crypto";
     import { PrimeWorkspaceStore } from ${JSON.stringify(moduleUrl())};
     const hash = value => createHash("sha256").update(JSON.stringify(value)).digest("hex");
     const store = new PrimeWorkspaceStore({
-      root: process.argv[1],
-      staleLockMs: 60000,
-      faultInjector(point) {
-        if (point === "after_temp_fsync") process.exit(92);
-      },
+      root: process.argv[1], staleLockMs: 60000,
+      faultInjector(point) { if (point === "after_temp_fsync") process.exit(92); },
     });
     store.atomicSetWithRollback({
-      key: "signal",
-      value: "after",
-      token: "crash-token",
-      expectedHash: hash("after"),
-      createdAt: new Date().toISOString(),
+      key: "signal", value: "after", token: "crash-token", expectedHash: hash("after"), createdAt: new Date().toISOString(),
+      proof: { proof_id: "crash-proof", operation: "set", receipt: { receipt_id: "crash-proof" }, verification: { valid: true }, runtime: {} },
     });
   `;
   const crashed = await runChild(code, [root]);
   assert.equal(crashed.exitCode, 92);
-
   const recovered = new PrimeWorkspaceStore({ root, staleLockMs: 60000 });
   assert.equal(recovered.get("signal"), "before");
   assert.equal(recovered.snapshot().rollbacks["crash-token"], undefined);
+  assert.equal(recovered.snapshot().proofs["crash-proof"], undefined);
   assert.equal(readdirSync(root).some(name => name.endsWith(".tmp")), false);
 });
 
@@ -89,16 +80,11 @@ test("successful commit remains rollback-capable after recovery path", () => {
   const root = mkdtempSync(join(tmpdir(), "prime-crash-control-"));
   try {
     const store = new PrimeWorkspaceStore({ root });
-    store.atomicSetWithRollback({
-      key: "signal",
-      value: "after",
-      token: "control-token",
-      expectedHash: sha256("after"),
-      createdAt: new Date().toISOString(),
-    });
+    store.atomicSetWithRollback({ key: "signal", value: "after", token: "control-token", expectedHash: sha256("after"), createdAt: new Date().toISOString(), proof: proof("control-proof", "set") });
     const recovered = new PrimeWorkspaceStore({ root });
     assert.equal(recovered.get("signal"), "after");
     assert.equal(recovered.snapshot().rollbacks["control-token"].used, false);
+    assert.equal(recovered.snapshot().latest_proof_id, "control-proof");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Couples each committed Prime workspace consequence to the exact verified RIO receipt returned by the API.

## Commit unit

```text
verified receipt candidate
+ workspace mutation
+ rollback capability or token burn
+ monotonic revision
+ durable proof record
→ one lock-held atomic canonical replacement
```

The HTTP response returns the same receipt bytes already persisted inside the committed workspace state.

## Implementation

- upgrades workspace state to version 2
- adds monotonic `revision`, `latest_proof_id`, and durable `proofs`
- generates and verifies the receipt before committing the consequence
- persists the exact receipt/runtime bundle atomically with set and rollback
- links each rollback record to its set proof and, once consumed, its rollback proof
- exposes `workspace_revision` and `durable_proof_id` in execution results
- requires every governed workspace revision to name an existing proof at the same revision
- fails closed during recovery when canonical state and proof linkage disagree
- preserves single-writer locking, crash recovery, rollback replay refusal, authentication, and native receipt verification

## Acceptance

```bash
cd gateway
npm ci
npm run test:prime
```

The suite proves:

- the returned receipt exactly equals the persisted durable proof
- set and rollback each advance exactly one proof-bound revision
- rollback records retain both set-proof and rollback-proof linkage
- state with its latest proof removed fails closed on startup
- proof with a mismatched revision fails closed on startup
- a crash before canonical rename persists neither consequence nor proof
- all existing runtime, route, persistence, concurrency, crash, rollback, and receipt tests remain green

## Boundary

This couples proof and consequence inside the isolated workspace commit unit. It does not yet replicate proof into the PostgreSQL append-only ledger; that becomes the next explicit crossing.