### PR TITLE
Add cross-register runtime placement note

### DIFF
--- a/docs/reconciliation/REGISTER-RECONCILIATION-RUNTIME-PLACEMENT-v0.1.md
+++ b/docs/reconciliation/REGISTER-RECONCILIATION-RUNTIME-PLACEMENT-v0.1.md
@@ -1,0 +1,79 @@
+# Cross-Register Runtime Placement
+
+## Status
+
+- **Classification:** runtime navigation and implementation-boundary note
+- **Standing:** informative
+- **Authority:** this note does not replace the runtime map or protocol sources
+- **Runtime effect:** none by placement alone
+
+## Purpose
+
+The architecture repository holds the cross-register bridge:
+
+- [Register Reconciliation and Developer Loom](https://github.com/bkr1297-RIO/one-rio-muss-architecture/blob/docs/architecture-repo-bootstrap/docs/reconciliation/README.md)
+- [REAL Intelligence ↔ ONE Grammar ↔ RIO Matrix v0.2](https://github.com/bkr1297-RIO/one-rio-muss-architecture/blob/docs/architecture-repo-bootstrap/docs/reconciliation/REAL-ONE-RIO-REGISTER-PROJECTION-STANDING-MATRIX-v0.2.md)
+
+This note places runtime work against that bridge without turning architecture language into an implementation claim.
+
+## Runtime jurisdiction
+
+This repository owns:
+
+- gateway and runtime behavior;
+- execution gates and authorization binding;
+- connectors and adapters;
+- runtime state and deployment status;
+- runtime tests and operational evidence.
+
+The matrix remains the cross-register map. This repository remains the authority for what is actually running here.
+
+## Runtime lowering route
+
+```text
+Constitutional / architectural responsibility
+        ↓
+Semantic or grammatical object
+        ↓
+RIO protocol projection
+        ↓
+Runtime state, gate, adapter, or service
+        ↓
+Receipt, ledger, verification, and return
+```
+
+Every runtime binding should declare:
+
+- the source concept and register;
+- the protocol object it consumes or emits;
+- the authority boundary;
+- the state transitions it permits;
+- the evidence it returns;
+- the behavior it does not implement.
+
+## Current enterprise-wedge boundary
+
+Sentinel Core belongs to the bounded developer-wedge lane described by the matrix. It can provide a portable gate, sealed receipt, transition attestation, and verification profile around existing systems. Its presence in the architecture map does not mean that Sentinel Core is the same thing as this gateway runtime, nor that its imported tests establish production deployment.
+
+## Claim discipline
+
+Runtime evidence may establish bounded behavior under a named profile. It does not, by itself, establish:
+
+- completion of ONE Grammar;
+- constitutional ratification;
+- bilateral sovereignty;
+- uncoerced human authority;
+- complete absence from a recording boundary;
+- production readiness beyond the tested deployment profile.
+
+## Contributor route
+
+Before adding a runtime surface:
+
+1. locate the concept and standing in the reconciliation matrix;
+2. identify the owning protocol object;
+3. define the runtime binding and failure-closed behavior;
+4. add tests at the claimed evidence level;
+5. update the runtime map with what is running, partial, planned, or absent.
+
+Runtime implementation realizes a declared responsibility. It does not inherit authority merely by operating it.


### PR DESCRIPTION
Adds a pointer to the merged architecture reconciliation matrix and defines how runtime contributors map concepts into RIO objects, runtime surfaces, and evidence without inflating implementation claims. Documentation only; no runtime behavior changed.