### PR TITLE
docs: add Rosetta claim governance integration surface

### DIFF
--- a/docs/claim-governance/CLAIM-GOVERNANCE-BUILD-ADAPTER-CANDIDATE-001_v0.1.md
+++ b/docs/claim-governance/CLAIM-GOVERNANCE-BUILD-ADAPTER-CANDIDATE-001_v0.1.md
@@ -1,0 +1,112 @@
+# CLAIM-GOVERNANCE-BUILD-ADAPTER-CANDIDATE-001 v0.1
+
+**Status:** CANDIDATE — not runtime code; not a live integration  
+**Depends on:** CLAIM-REGISTRY-CONTROL-SURFACE-001_v0.1.md  
+**No runtime change. No OpenAPI change. No package change.**
+
+---
+
+## 1. Purpose
+
+This document defines the candidate design for how future build systems may consume the
+Claim Registry as a governance gate.  It is a design specification only.  Nothing
+described here is currently implemented.  Authorization is required before any build
+integration is attempted.
+
+---
+
+## 2. Candidate Consumption Points
+
+Future build systems may read registry state to govern the following surfaces:
+
+| Surface | Registry role |
+|---|---|
+| **Onboarding language** | Source framing language from public-proposition claims at Formalized or above; block use of any claim flagged PENDING HUMAN REVIEW |
+| **Doctrine / reference pages** | Surface claims at Documented or above; annotate claims below Verified with maturity indicator |
+| **Public / private register separation** | Never surface personal-protocol or private-meaning register content on any public-facing page |
+| **RIO / Scribe language gates** | Require runtime-evidence register and Implemented or above before including a claim in system-level documentation |
+| **Admin review workflow** | Expose PENDING HUMAN REVIEW flag count and individual flag status to admins; do not auto-clear flags |
+| **Claim metadata** | Display claim ID, register, maturity, evidence gate, and public posture alongside any surfaced claim |
+
+---
+
+## 3. Required Adapter Interface (Candidate)
+
+A conforming build adapter must support the following read operations against the
+registry:
+
+| Operation | Description |
+|---|---|
+| `read_claim_id` | Return the stable identifier for a claim row |
+| `read_register` | Return the register assignment: `public_proposition`, `runtime_evidence`, `personal_protocol`, or `private_meaning` |
+| `read_maturity` | Return the maturity level: `declared`, `documented`, `formalized`, `implemented`, or `verified` |
+| `read_evidence_gate` | Return whether sufficient evidence is recorded to support the current maturity level |
+| `read_public_posture` | Return whether the claim is designated as surface-able on public-facing pages |
+| `read_review_flag` | Return the current review flag: `PENDING HUMAN REVIEW`, `CLEARED`, or `NOT FLAGGED` |
+
+---
+
+## 4. Required Blocking Rules
+
+An adapter must enforce the following blocking rules; no workaround or override may be
+implemented at the build layer:
+
+| Rule | Trigger | Consequence |
+|---|---|---|
+| **Pending block** | `read_review_flag` returns `PENDING HUMAN REVIEW` | Block product-facing use of the claim on all surfaces without exception |
+| **Runtime/security gate** | Claim is used in a runtime or security context AND (`read_maturity` < `implemented` OR `read_evidence_gate` = false) | Block inclusion; log the claim ID and failure reason |
+| **Private register block** | `read_register` returns `personal_protocol` or `private_meaning` | Block all public-facing use unconditionally |
+| **Uncleared scientific claim** | Claim describes a research hypothesis or empirical result AND `read_maturity` < `verified` | Block use in any scientific or technical output |
+
+---
+
+## 5. What the Adapter Must Not Do
+
+- Auto-promote a claim (change its maturity) based on build outputs.
+- Clear a PENDING HUMAN REVIEW flag programmatically.
+- Write to the registry (the registry is read-only from the build adapter's perspective).
+- Surface a claim's personal-protocol or private-meaning text on any public page.
+- Treat evidence accumulation as equivalent to human review.
+- Assert that any claim is "proven" or "verified" without the registry's own Verified
+  maturity level being present.
+
+---
+
+## 6. Relationship to Existing Governance
+
+| Existing surface | Adapter relationship |
+|---|---|
+| SPG-M intake | SPG-M governs system prompts at intake; the claim adapter governs documentation surfaces. They operate at different layers and must not be conflated. |
+| UIF facade | UIF governs what intent is accepted at the public facade; claim governance governs what claims may appear in documentation. No coupling at runtime. |
+| RIO intent flow | A claim in the `runtime_evidence` register at `implemented` or above may describe RIO intent behavior; it does not alter that behavior. |
+
+---
+
+## 7. Implementation Prerequisites
+
+Before any build adapter is implemented:
+
+1. The Claim Registry must be published to a machine-readable format (CSV, JSON, or API)
+   that the build system can consume without a human manually exporting the workbook.
+2. A review workflow must be defined so that PENDING HUMAN REVIEW claims can be cleared
+   by an identified, accountable reviewer without requiring a full registry export.
+3. A claim ID stability guarantee must exist: IDs must not change between registry
+   versions, or the adapter will produce incorrect blocks on renamed claims.
+4. Authorization from the project owner is required before any live integration is
+   attempted.
+
+This is not a request for those prerequisites to be built.  It is a record of what must
+exist before the adapter can be implemented.
+
+---
+
+## 8. Non-Claims
+
+- This document does not claim the adapter exists.
+- This document does not claim the registry is currently machine-readable.
+- This document does not claim any claim has been verified.
+- This document does not claim build governance is currently enforced.
+
+---
+
+*Docs only. No runtime code. No live integration. No new dependency. No OpenAPI change.*

--- a/docs/claim-governance/CLAIM-REGISTRY-CONTROL-SURFACE-001_v0.1.md
+++ b/docs/claim-governance/CLAIM-REGISTRY-CONTROL-SURFACE-001_v0.1.md
@@ -1,0 +1,125 @@
+# CLAIM-REGISTRY-CONTROL-SURFACE-001 v0.1
+
+**Status:** CANDIDATE  
+**Location of record:** Drive (ONE_RIO_MUSS_Claim_Registry_v0.1.xlsx)  
+**Repo role:** Reference — claim posture and control surface  
+**No runtime change. No private claim text reproduced here.**
+
+---
+
+## 1. Purpose
+
+The Claim Registry is the posture and control surface for claims made within or about
+the ONE / RIO / MUSS system.  This document defines the registry's verified structure,
+its current state, its standing rules, and the boundary between what the registry may do
+and what it may not do.
+
+---
+
+## 2. Verified Registry Structure
+
+The workbook contains the following sheets:
+
+| Sheet | Role |
+|---|---|
+| **CONTROL PANEL** | Summary view; current maturity distribution; active flags |
+| **CLAIMS** | The canonical claim table: ID, register, text, maturity, evidence gate, public posture, review flag |
+| **TAXONOMY** | Register and maturity level definitions |
+| **PROMOTION RULES** | Conditions and authority required to advance a claim's maturity level |
+| **SOURCES** | Evidence references attached to individual claims |
+| **CHANGELOG** | Dated record of additions, edits, flag changes, and promotions |
+
+---
+
+## 3. Verified Counts (as of ingest)
+
+| Metric | Value |
+|---|---|
+| Total claims | 36 |
+| Structurally complete / prior corpus retained | 19 |
+| Pending human review | 17 |
+
+---
+
+## 4. Registers
+
+Claims are assigned to one of four registers:
+
+| Register | Description |
+|---|---|
+| **Public proposition** | Stated positions open to examination and challenge |
+| **Runtime evidence** | Observations produced by running systems |
+| **Personal protocol** | Individual operating rules and self-governance conventions |
+| **Private meaning** | Internally-held interpretations; furnace material |
+
+---
+
+## 5. Maturity Levels
+
+| Level | Meaning |
+|---|---|
+| **Declared** | Claim has been stated; no supporting evidence required yet |
+| **Documented** | Claim is accompanied by explanatory material |
+| **Formalized** | Claim has been expressed in a structured, reviewable form |
+| **Implemented** | Claim is reflected in working code or system behavior |
+| **Verified** | Claim has been examined and confirmed against evidence |
+
+---
+
+## 6. Promotion Rules
+
+Promotion of a claim to a higher maturity level requires **human review**.  Evidence may
+support promotion; it does not authorize it.  No automated process, build system, or
+agent action constitutes a promotion event.  All promotion events must be recorded in the
+CHANGELOG sheet with date and reviewer.
+
+---
+
+## 7. Standing Rules for Pending Claims
+
+Claims with a review flag of **PENDING HUMAN REVIEW** are subject to the following hard
+constraints:
+
+- Must not become product-facing claims in any UI, onboarding flow, or public document.
+- Must not become technical claims in any specification, API contract, or schema.
+- Must not become scientific claims in any research output or methodology statement.
+- Must not become canonical claims in any policy, governance contract, or legal document.
+
+A claim is pending until a human reviewer explicitly clears it.  Time passing, evidence
+accumulating, or maturity advancing does not clear a pending flag.
+
+---
+
+## 8. What the Registry May Do
+
+- Recommend classification of a claim by register and maturity.
+- Track evidence associated with a claim.
+- Flag claims for review.
+- Record promotion decisions made by human reviewers.
+- Produce summaries and views of claim posture.
+
+---
+
+## 9. What the Registry May Not Do
+
+- **Publish** a claim (make it product-facing or externally visible) autonomously.
+- **Authorize** promotion without human review.
+- **Execute** any system action on the basis of a claim.
+- **Canonize** a claim (establish it as settled truth) without formal review and
+  acknowledgment.
+
+These prohibitions are permanent constraints of the registry's role, not temporary
+limitations to be lifted by a future version.
+
+---
+
+## 10. Drive Location
+
+The canonical working copy of the Claim Registry lives in Drive.  Drive is the working
+and control location.  No row from the CLAIMS sheet is reproduced verbatim in this
+document.  Any substantive update to registry structure or counts must originate in Drive
+and be reflected here by amendment, not by pasting workbook content into the repo.
+
+---
+
+*Docs only. No runtime code. No new dependency. No OpenAPI change.*

--- a/docs/claim-governance/ROSETTA-LAYER-INGEST-001_v0.1.md
+++ b/docs/claim-governance/ROSETTA-LAYER-INGEST-001_v0.1.md
@@ -1,0 +1,84 @@
+# ROSETTA-LAYER-INGEST-001 v0.1
+
+**Status:** CANDIDATE  
+**Location of record:** Drive (ONE_RIO_MUSS_Rosetta_Introduction_v0.1.docx)  
+**Repo role:** Reference — orientation and translation layer only  
+**No runtime change. No private claim text reproduced here.**
+
+---
+
+## 1. Purpose
+
+The Rosetta Introduction artifact is the public-facing orientation and translation layer
+for the ONE / RIO / MUSS architecture.  It exists to help readers understand how
+concepts in one domain map to concepts in another without requiring them to hold every
+cross-domain hypothesis simultaneously.
+
+This document records how the Rosetta layer is ingested into the repo surface: what it
+may do, what boundaries it preserves, and what it must not claim.
+
+---
+
+## 2. What the Rosetta Layer Does
+
+- Provides plain-language orientation to the architecture for new contributors and
+  reviewers.
+- Translates between register vocabularies so that a reader grounded in, e.g., runtime
+  evidence language can navigate personal-protocol or public-proposition concepts without
+  assuming they are the same thing.
+- Makes the architecture legible without requiring the reader to accept every
+  cross-domain hypothesis as settled.
+
+The Rosetta Introduction is **explanatory**, not **evidentiary**.  It helps explain the
+architecture; it does not prove any research hypothesis.
+
+---
+
+## 3. Register Boundaries Preserved
+
+The Rosetta layer does not collapse the following registers into one another:
+
+| Register | Description | Repo visibility |
+|---|---|---|
+| **Private meaning** | Personal, internally-held interpretations; furnace material | Not reproduced in repo |
+| **Personal protocol** | Individual operating rules and self-governance conventions | Not reproduced in repo |
+| **Public proposition** | Stated positions that can be examined, challenged, and revised | May appear in repo docs as attributed propositions |
+| **Runtime evidence** | Observations and outputs produced by running systems | May appear in repo docs as traceable artifacts |
+
+GitHub may reference the Rosetta layer and its public-proposition content.  It must not
+absorb private furnace material.  The presence of a Rosetta document in Drive does not
+grant permission to reproduce its private-meaning or personal-protocol content in any
+repo file.
+
+---
+
+## 4. What the Rosetta Layer Does Not Do
+
+- Does not prove any cross-domain hypothesis.
+- Does not authorize promotion of claims from one register to another.
+- Does not replace the Claim Registry as the posture and control surface.
+- Does not itself constitute a canonical runtime specification.
+- Does not override SPG-M, UIF, or any existing governance contract.
+
+---
+
+## 5. Relationship to Other Governance Docs
+
+| Document | Relationship |
+|---|---|
+| `CLAIM-REGISTRY-CONTROL-SURFACE-001_v0.1.md` | The registry is the claim posture surface; Rosetta is the orientation layer. They are complementary, not interchangeable. |
+| `CLAIM-GOVERNANCE-BUILD-ADAPTER-CANDIDATE-001_v0.1.md` | A future build adapter may surface Rosetta-layer language in onboarding copy; it must still gate on registry maturity and review flag. |
+| UIF / SPG-M docs | Rosetta may be cited as explanatory context; it does not alter those contracts. |
+
+---
+
+## 6. Drive Location
+
+The canonical working copy of the Rosetta Introduction lives in Drive.  Drive is the
+working and control location.  The repo holds a reference only.  Any substantive update
+to the Rosetta layer must originate in Drive and be reflected here by amendment of this
+document, not by pasting Drive content into the repo.
+
+---
+
+*Docs only. No runtime code. No new dependency. No OpenAPI change.*


### PR DESCRIPTION
## docs: add Rosetta claim governance integration surface

    ### Summary

    - Adds docs-only Rosetta/Claim Registry integration surface under `docs/claim-governance/`
    - Preserves Drive as the working and control location for both artifacts
    - Prevents pending claims from becoming product-facing, technical, scientific, or canonical claims
    - No runtime changes

    ---

    ### What this PR contains

    Three new docs-only files. No runtime code. No OpenAPI change. No package or dependency change.

    | File | Purpose |
    |---|---|
    | `docs/claim-governance/ROSETTA-LAYER-INGEST-001_v0.1.md` | Records the Rosetta Introduction as the public orientation and translation layer; preserves the four register boundaries (private meaning, personal protocol, public proposition, runtime evidence); states that GitHub may reference the Rosetta layer but must not absorb private furnace material |
    | `docs/claim-governance/CLAIM-REGISTRY-CONTROL-SURFACE-001_v0.1.md` | Defines the Claim Registry as the posture and control surface; documents verified workbook structure (CONTROL PANEL, CLAIMS, TAXONOMY, PROMOTION RULES, SOURCES, CHANGELOG); records verified counts (36 total, 19 complete, 17 pending); states that pending claims must not become product-facing/technical/scientific/canonical; states registry may recommend, classify, track — may not publish, authorize, execute, or canonize |
    | `docs/claim-governance/CLAIM-GOVERNANCE-BUILD-ADAPTER-CANDIDATE-001_v0.1.md` | Candidate design for how future build systems may consume the registry; defines required read operations (claim ID, register, maturity, evidence gate, public posture, review flag); defines mandatory blocking rules (pending block, runtime/security gate, private register block, uncleared scientific claim); states implementation prerequisites; explicitly not a live integration |

    ---

    ### No docs/README.md update

    No `docs/README.md` exists in the repo; no broad site map was created. The existing `docs/` directory structure is unchanged.

    ---

    ### Test / lint results

    The instruction asked to run whatever existing doc/lint/test command is standard for the repo.

    SPG-M unit tests were run against the current `main` code (no source change from this PR — docs only):

    | Command | Result |
    |---|---|
    | `npm run test:spgm:policy-review` | **5/5 pass** |
    | `npm run test:spgm:govern` | **14/14 pass** |
    | `npm run test:spgm:openapi` | **4/4 pass** |
    | `npm run test:spgm` (full suite) | 48/50 pass; 2 pre-existing failures in spgm-intake.test.mjs unrelated to this PR |
    | `npm test` (HTTP integration) | Requires a running gateway server on port 4401; ECONNREFUSED locally; not affected by docs |

    No doc-specific lint or build command was found in the gateway package.json. No applicable test command for docs-only files was identified beyond the above.

    ---

    ### Constraints confirmed

    - No runtime code added
    - No OpenAPI changes
    - No package or dependency changes
    - No private or personal claim text reproduced in the repo
    - No Drive writes
    - No publication or outreach
    - No claim that the registry is automatically enforced at runtime
    - No claim that Rosetta proves any research hypothesis
    - All files use ASCII Markdown
    - Drive remains the working and control location for both Drive artifacts